### PR TITLE
added overflow hidden to remove the text wrapping on long file names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.8.5)
+    nfg_ui (0.9.8.6)
       bootstrap (= 4.2.1)
       browser (~> 1.1)
       coffee-script
@@ -61,7 +61,7 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
-    autoprefixer-rails (9.4.7)
+    autoprefixer-rails (9.4.8)
       execjs
     bootstrap (4.2.1)
       autoprefixer-rails (>= 9.1.0)
@@ -269,4 +269,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.0
+   1.17.3

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom_forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom_forms.scss
@@ -53,6 +53,7 @@
   font-weight: $font-weight-normal;
   cursor: pointer;
   border-radius: 0 $btn-border-radius $btn-border-radius 0;
+  overflow: hidden;
   &::after {
     font-weight: $btn-font-weight;
     border-radius: 0 $btn-border-radius $btn-border-radius 0;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/nfg_theme/_custom_forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/nfg_theme/_custom_forms.scss
@@ -53,6 +53,7 @@
   font-weight: $font-weight-normal;
   cursor: pointer;
   border-radius: 0 $btn-border-radius $btn-border-radius 0;
+  overflow: hidden;
   &::after {
     font-weight: $btn-font-weight;
     border-radius: 0 $btn-border-radius $btn-border-radius 0;

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.8.5'.freeze
+  VERSION = '0.9.8.6'.freeze
 end


### PR DESCRIPTION
The purpose of this branch was to fix an issue with custom file input filename length being too long and wrapping down below the input's box. 

Example:
![image](https://user-images.githubusercontent.com/5702623/53252996-37be8700-368e-11e9-8212-378d485565da.png)
