### PR TITLE
Hotfix/carousel indicators are showing up with white background

### DIFF
--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/_variables.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/_variables.scss
@@ -1062,8 +1062,8 @@ $carousel-indicator-width:           ($spacer * .5);
 $carousel-indicator-height:          ($spacer * .5);
 // $carousel-indicator-hit-area-height: 10px !default;
 $carousel-indicator-spacer:          ($spacer * .25);
-// $carousel-indicator-active-bg:       $white !default;
-$carousel-indicator-transition:      $gray-600;
+$carousel-indicator-active-bg:       $text-muted;
+$carousel-indicator-transition:      $text-muted;
 
 // $carousel-caption-width:             70% !default;
 // $carousel-caption-color:             $white !default;

--- a/lib/nfg_ui/bootstrap/components/carousel.rb
+++ b/lib/nfg_ui/bootstrap/components/carousel.rb
@@ -25,7 +25,7 @@ module NfgUi
         def render
           super do
             capture do
-              content_tag(:div, class: 'carousel-inner pb-3') do
+              content_tag(:div, class: 'carousel-inner') do
                 if indicators > 0
                   concat(NfgUi::Bootstrap::Components::CarouselIndicators.new({ count: indicators, carousel: "##{id}" }, view_context).render)
                 end

--- a/lib/nfg_ui/bootstrap/components/carousel.rb
+++ b/lib/nfg_ui/bootstrap/components/carousel.rb
@@ -25,7 +25,7 @@ module NfgUi
         def render
           super do
             capture do
-              content_tag(:div, class: 'carousel-inner') do
+              content_tag(:div, class: 'carousel-inner pb-3') do
                 if indicators > 0
                   concat(NfgUi::Bootstrap::Components::CarouselIndicators.new({ count: indicators, carousel: "##{id}" }, view_context).render)
                 end

--- a/lib/nfg_ui/components/patterns/carousel.rb
+++ b/lib/nfg_ui/components/patterns/carousel.rb
@@ -13,7 +13,7 @@ module NfgUi
 
         def render
           content_tag(:div, html_options) do
-            content_tag(:div, class: 'carousel-inner') do
+            content_tag(:div, class: 'carousel-inner pb-3') do
               concat((block_given? ? yield : body))
               if controls
                 concat(NfgUi::Components::Elements::CarouselControl.new({ control: :next, carousel: "##{id}" }, view_context).render)

--- a/spec/lib/nfg_ui/components/patterns/carousel_spec.rb
+++ b/spec/lib/nfg_ui/components/patterns/carousel_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe NfgUi::Components::Patterns::Carousel do
   let(:carousel) { described_class.new(options, ActionController::Base.new.view_context) }
+  let(:rendered) { carousel.render }
   let(:options) { {} }
   it { expect(described_class).to be < NfgUi::Bootstrap::Components::Carousel }
   it_behaves_like 'a component with a consistent initalized construction'
@@ -9,4 +10,14 @@ RSpec.describe NfgUi::Components::Patterns::Carousel do
   it_behaves_like 'a component that includes the Renderable utility module'
 
   it { expect(described_class.included_modules).to include NfgUi::Components::Utilities::Traitable }
+
+
+  describe '#render' do
+    subject { Capybara.string(rendered) }
+
+    it 'includes a unique padding on the inner carousel' do
+      expect(subject).to have_css '.carousel-inner.pb-3'
+    end
+
+  end
 end

--- a/spec/lib/nfg_ui/components/patterns/carousel_spec.rb
+++ b/spec/lib/nfg_ui/components/patterns/carousel_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NfgUi::Components::Patterns::Carousel do
   describe '#render' do
     subject { Capybara.string(rendered) }
 
-    it 'includes a unique padding on the inner carousel' do
+    it 'includes a unique padding on the inner carousel that is designed to facilitate a text-based carousel like a donor scroll instead of a hero banner image-based carousel' do
       expect(subject).to have_css '.carousel-inner.pb-3'
     end
 


### PR DESCRIPTION
This fixes the color issue we were having with the carousel indicators and also adds the spacer class at the bottom of the carousel for the indicators (absolutely positioned)