### PR TITLE
Feature/pstwo 13132 z index problem with select2 menu and admin evo sticky header

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.8.11)
+    nfg_ui (0.9.8.12)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)
@@ -100,8 +100,8 @@ GEM
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     ffi (1.10.0)
-    font-awesome-rails (4.7.0.4)
-      railties (>= 3.2, < 6.0)
+    font-awesome-rails (4.7.0.5)
+      railties (>= 3.2, < 6.1)
     foundation_emails (2.2.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -110,7 +110,7 @@ GEM
       tilt
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    inky-rb (1.3.7.4)
+    inky-rb (1.3.7.5)
       foundation_emails (~> 2)
       nokogiri
     io-like (0.3.0)
@@ -197,7 +197,7 @@ GEM
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -211,7 +211,7 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
-    sassc-rails (2.1.0)
+    sassc-rails (2.1.1)
       railties (>= 4.0.0)
       sassc (>= 2.0)
       sprockets (> 3.0)

--- a/TRAITS_OR_OPTION_PATTERNS_NOTED.md
+++ b/TRAITS_OR_OPTION_PATTERNS_NOTED.md
@@ -33,3 +33,12 @@ However, the design pattern is actually:
 A `:boolean` trait combined with a `condition:` option might look like this:
 `= ui.nfg :icon, :boolean, condition: entity.has_link_to_website?`
 Which would then check the condition, if true: output the success themed check icon with "Yes" text, etc.
+
+2. An external link trait, e.g. :external would convert:
+```
+= ui.nfg :icon, 'external-link', text: t('.links.stored_consent_agreement'), right: true
+```
+And used as a trait:
+```
+= ui.nfg :icon, :external, text: t('.links.stored_consent_agreement')
+```

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_custom-forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_custom-forms.scss
@@ -5,7 +5,7 @@
 .custom-select {
   background-image: none;
   &::-ms-expand {
-    display: inherit;
+    display: block;
   }
 }
 

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_custom-forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_custom-forms.scss
@@ -3,8 +3,10 @@
 .custom-control-inline { display: -ms-inline-flexbox; }
 
 .custom-select {
-  background-size: 30%;
-  background-position-x: right 0px;
+  background-image: none;
+  &::-ms-expand {
+    display: inherit;
+  }
 }
 
 .custom-switch {

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_custom-forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_custom-forms.scss
@@ -2,13 +2,6 @@
 
 .custom-control-inline { display: -ms-inline-flexbox; }
 
-.custom-select {
-  background-image: none;
-  &::-ms-expand {
-    display: block;
-  }
-}
-
 .custom-switch {
   .custom-control-label {
     &::before {

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
@@ -1,7 +1,7 @@
 // IE10 only
 &.no-flexbox {
   select {
-    background-image: none !important;
+    background: $white !important;
     &::-ms-expand { display: block !important; }
   }
 }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
@@ -1,6 +1,7 @@
 // IE10 only
 &.no-flexbox {
   select {
+    padding-right: 12px;
     background: #FFFFFF !important;
     &::-ms-expand { display: block !important; }
   }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
@@ -1,8 +1,12 @@
-// Fixes issue with padding on select fields
-select {
-  padding-left: 10px;
-  padding-right: 15px;
+// IE10 only
+&.no-flexbox {
+  select {
+    background-image: none !important;
+    &::-ms-expand { display: block !important; }
+  }
 }
+
+// Fixes padding issue on file inputs
 input[type='file'] {
   padding: 0;
   border: none;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/_forms.scss
@@ -1,7 +1,7 @@
 // IE10 only
 &.no-flexbox {
   select {
-    background: $white !important;
+    background: #FFFFFF !important;
     &::-ms-expand { display: block !important; }
   }
 }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_datepicker.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_datepicker.scss
@@ -1,2 +1,2 @@
 // fixes z-index issue for default datepicker
-.ui-datepicker { z-index: $zindex-popover !important; }
+.ui-datepicker { z-index: $zindex-dropdown !important; }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_select2.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_select2.scss
@@ -10,7 +10,7 @@
 .select2.select2-hidden-accessible { width: auto !important; } // Prevents horizontal scrolling on designation select on donation form
 
 body:not(.modal-open) {
-  .select2-container--default { z-index: 901; }
+  .select2-container--default { z-index: $zindex-dropdown; }
 }
 
 .select2-container--default {
@@ -33,7 +33,7 @@ body:not(.modal-open) {
     vertical-align: middle;
     background: $custom-select-bg $custom-select-indicator no-repeat right $custom-select-padding-x center;
     background-size: $custom-select-bg-size;
-    border: $custom-select-border-width solid $custom-select-border-color;
+    border: $custom-select-border-width solid $custom-select-border-color !important;
     border-radius: $border-radius;
     outline: none;
     cursor: pointer;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_sticky_div.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_sticky_div.scss
@@ -7,5 +7,5 @@
   top: 0;
   z-index: ($zindex-dropdown - 1);
   transition: $transition-base;
-  &.stuck { z-index: ($zindex-tooltip + 1); }
+  &.stuck { z-index: $zindex-sticky; }
 }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_sticky_div.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/plugins/_sticky_div.scss
@@ -5,6 +5,7 @@
   position: sticky;
   position: -webkit-sticky;
   top: 0;
-  z-index: 999;
+  z-index: ($zindex-dropdown - 1);
   transition: $transition-base;
+  &.stuck { z-index: ($zindex-tooltip + 1); }
 }

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.8.11'
+  VERSION = '0.9.8.12'
 end


### PR DESCRIPTION
Z-index issue with select2 covering the page-header.

It now shows above before scroll:
<img width="867" alt="Screen Shot 2019-04-24 at 12 14 30 PM" src="https://user-images.githubusercontent.com/16546623/56675638-a322d600-668a-11e9-841e-8b6a3818a1aa.png">

and below on scroll:
<img width="759" alt="Screen Shot 2019-04-24 at 12 14 37 PM" src="https://user-images.githubusercontent.com/16546623/56675650-aa49e400-668a-11e9-9d39-e0b280a03bf6.png">

I also added in support for selects to display the browser default arrow in IE10 and lower. IE11+ have the custom arrow and displayed correctly. This fix comes from UX/UI Trello board (Wonky select menu toggle icon on ie11)

This PR needs to be merged into master before completing the EVO branch.