### PR TITLE
Feature/pstwo 13318 convert admins listing page to nfg ui

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
+gem 'haml'
+
 group :development do
   gem 'spring'
   gem 'spring-watcher-listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,12 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.8.16)
+    nfg_ui (0.9.8.18)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)
       coffee-script (~> 2.4)
       font-awesome-rails (~> 4.7)
-      haml (~> 5.0)
       inky-rb (~> 1.3.7)
       jquery-rails (~> 4.3)
       rails (>= 4.2.0)
@@ -262,6 +261,7 @@ DEPENDENCIES
   capybara (~> 3.9)
   chromedriver-helper (~> 2.1)
   factory_bot_rails (~> 4.11)
+  haml
   nfg_ui!
   puma (~> 3.12)
   rails-controller-testing (~> 1.0)

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_slat.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_slat.scss
@@ -24,12 +24,11 @@
       flex-grow: 2;
 
       // Sizing options
-      &.slat-item-sm { flex-grow: 0; }
+      &.slat-item-sm { flex-grow: 1; }
       &.slat-item-lg { flex-grow: 6; }
     }
   }
 }
-
 
 
 // Action Column

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/custom/_slat.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/legacy_browser_support/nfg_theme/custom/_slat.scss
@@ -21,7 +21,7 @@
       -ms-flex-positive: 2;
 
       // Sizing options
-      &.slat-item-sm { -ms-flex-positive: 0; }
+      &.slat-item-sm { -ms-flex-positive: 1; }
       &.slat-item-lg { -ms-flex-positive: 6; }
     }
   }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/nfg_theme/custom/_slat.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/nfg_theme/custom/_slat.scss
@@ -24,7 +24,7 @@
       flex-grow: 2;
 
       // Sizing options
-      &.slat-item-sm { flex-grow: 0; }
+      &.slat-item-sm { flex-grow: 1; }
       &.slat-item-lg { flex-grow: 6; }
     }
   }

--- a/lib/nfg_ui/bootstrap/components/base.rb
+++ b/lib/nfg_ui/bootstrap/components/base.rb
@@ -54,7 +54,8 @@ module NfgUi
         end
 
         def html_options
-          options.except(*non_html_attribute_options)
+
+          options.except(*non_html_attribute_options.uniq)
                  .merge!(id: id,
                          class: css_classes,
                          data: data,
@@ -122,7 +123,7 @@ module NfgUi
         # adding a new string of css classes to this method
         # ex: super.push('new-class')
         def css_classes
-          @css_classes ||= [component_css_class, options[:class]].join(' ').squish
+          @css_classes ||= [component_css_class, options[:class]].reject(&:nil?).uniq.join(' ').squish
         end
 
         def defaults

--- a/lib/nfg_ui/bootstrap/components/base.rb
+++ b/lib/nfg_ui/bootstrap/components/base.rb
@@ -54,7 +54,6 @@ module NfgUi
         end
 
         def html_options
-
           options.except(*non_html_attribute_options.uniq)
                  .merge!(id: id,
                          class: css_classes,

--- a/lib/nfg_ui/components/patterns/slat_actions.rb
+++ b/lib/nfg_ui/components/patterns/slat_actions.rb
@@ -5,8 +5,6 @@ module NfgUi
     module Patterns
       # Slat doc coming soon
       class SlatActions < NfgUi::Components::Base
-        # include NfgUi::Components::Traits::Theme
-
         # Includes a workaround suite of functionality
         # to integrate a singular SlatAction automatically when
         # The SlatActions component is rendered when the `:menu` option is set to false.

--- a/lib/nfg_ui/components/patterns/slat_actions.rb
+++ b/lib/nfg_ui/components/patterns/slat_actions.rb
@@ -5,61 +5,48 @@ module NfgUi
     module Patterns
       # Slat doc coming soon
       class SlatActions < NfgUi::Components::Base
-        include NfgUi::Components::Utilities::Iconable
+        # include NfgUi::Components::Traits::Theme
 
-        include NfgUi::Components::Traits::Theme
+        # Includes a workaround suite of functionality
+        # to integrate a singular SlatAction automatically when
+        # The SlatActions component is rendered when the `:menu` option is set to false.
+        #
+        # When menu is set to false:
+        # You can then pass in SlatAction options in the parent SlatAction
+        #
+        # Example usage:
+        # ui.nfg(:slat_actions, menu: false, theme: :parent, body: 'My Custom Slat Action')
+        # require 'nfg_ui/components/utilities/patches/integrated_slat_action'
+        include NfgUi::Components::Utilities::Patches::IntegratedSlatAction
 
         def component_family
           :slats
         end
 
+        # Signals whether or not this SlatActions will house a menu
+        # This is a critical condition.
+        # When false, a SlatAction is automatically integrated on your behalf.
         def menu
           options.fetch(:menu, true)
         end
 
-        def confirm
-          options.fetch(:confirm, nil)
-        end
-
-        def method
-          return if delete_link?
-          options.fetch(:method, nil)
-        end
-
-        def delete_link?
-          @delete_link ||= options.fetch(:method, nil) == :delete
-        end
-
+        # Signal if this slat_action is being used
+        # In the slat_header area of the Slats
+        #
+        # If so, this then customizes the output of the
+        # SlatActions to ensure that the widths of the slat_header columns
+        # is accurate and matches the width of the slats below.
         def slat_header
           options.fetch(:slat_header, false)
         end
 
+        # Signals if this is a wide SlatActions.
+        # This is a stylistic update which is used in situations like shopping carts where
+        # you may only be providing a summary and have no actions or extra columns.
+        #
+        # Note: Further documentation is needed on this
         def wide
           options.fetch(:wide, true)
-        end
-
-        def disable_with
-          options.fetch(:disable_with, nil)
-        end
-
-        def remote
-          options.fetch(:remote, nil)
-        end
-
-        def action_link_html_options
-          { href: href,
-            class: [
-                     (theme ? "text-#{theme}" : ''),
-                     'd-block'
-                   ].join(' ').squish,
-            method: send(:method),
-            remote: remote,
-            data: { disable_with: disable_with,
-                    confirm: confirm }.merge(delete_link? ? { method: :delete } : {}) }
-        end
-
-        def theme
-          options.fetch(:theme, nil)
         end
 
         def render
@@ -70,7 +57,7 @@ module NfgUi
               else
                 NfgUi::Components::Patterns::Dropdown.new({ }, view_context).render do
                   capture do
-                    concat(NfgUi::Components::Elements::DropdownToggle.new({ traits: [:outlined, :secondary], body: ('Actions' if wide)}, view_context).render)
+                    concat(NfgUi::Components::Elements::DropdownToggle.new({ **default_dropdown_toggle_options, body: ('Actions' if wide)}, view_context).render)
                     concat(NfgUi::Components::Patterns::DropdownMenu.new({ traits: [:right] }, view_context).render {
                       (block_given? ? yield : body)
                     })
@@ -78,26 +65,18 @@ module NfgUi
                 end
               end
             else
-              if href.present?
-                content_tag(:a, href: href, **action_link_html_options) do
-                  if icon
-                    NfgUi::Components::Foundations::Icon.new({ traits: [icon], text: (block_given? ? yield : body), theme: theme }, view_context).render
-                  else
-                    (block_given? ? yield : body)
-                  end
-                end
-              else
-                if icon
-                  NfgUi::Components::Foundations::Icon.new({ traits: [icon], text: (block_given? ? yield : body), theme: theme }, view_context).render
-                else
-                  (block_given? ? yield : body)
-                end
-              end
+              # Render the integrated slat action and pass in all of the
+              # related slat action options that are present in this SlatActions `:options`
+              render_integrated_slat_action
             end
           end
         end
 
         private
+
+        def default_dropdown_toggle_options
+          { outlined: true, theme: :secondary }
+        end
 
         def css_classes
           [
@@ -107,7 +86,7 @@ module NfgUi
         end
 
         def non_html_attribute_options
-          super.push(:slat_header, :wide, :menu, :theme, :method, :remote, :confirm, :disable_with)
+          super.push(:slat_header, :wide, :menu)
         end
       end
     end

--- a/lib/nfg_ui/components/traits/theme.rb
+++ b/lib/nfg_ui/components/traits/theme.rb
@@ -5,17 +5,20 @@ module NfgUi
     module Traits
       # Access to pre-designed theme traits
       module Theme
-        # TODO: Figure out how to get NfgUi::BOOTSTRAP_THEMES to be recognized for TRAITS
-        TRAITS = %i[primary
-                    secondary
-                    success
-                    danger
-                    warning
-                    info
-                    light
-                    dark
-                    white
-                    outlined].freeze
+        COLOR_TRAITS = %i[primary
+                          secondary
+                          success
+                          danger
+                          warning
+                          info
+                          light
+                          dark
+                          white]
+
+        TRAITS = [*COLOR_TRAITS,
+                  :outlined].freeze
+
+
 
         def primary_trait
           options[:theme] = :primary

--- a/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
+++ b/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
@@ -9,6 +9,8 @@ module NfgUi
         # SlatAction  - is the equivalent of a dropdown menu item
         # SlatActions - is the parent / wrapping component of the SlatAction(s)
         #
+        # and... Integrated Slat Action essentially replaces a dropdown toggle & dropdown menu with either a text link or a button component.
+        #
         # Usage: When you are creating a slat that does not need a menu but has a singular action link
         # For example: when the only option you have on a slat is to delete that item.
         #
@@ -25,12 +27,11 @@ module NfgUi
         # This is a monkeypatch while we re-evaluate the Slat component suite
         # so as not to break existing code implementation on our apps.
         module IntegratedSlatAction
-          # Allows for icons to be passed into the integrated SlatAction
+          # Allows for icons to be passed into the integrated slat action component
           include NfgUi::Components::Utilities::Iconable
 
-          # Allows for using theme traits on the SlatActions component
+          # Allows for using theme traits on the slat action component
           # that is then passed through to the integrated slat action.
-          # Note:
           include NfgUi::Components::Traits::Theme
 
           # This sets whether or not the SlatAction is a button.
@@ -44,14 +45,14 @@ module NfgUi
             options.fetch(:button, false)
           end
 
-          # Passes in the rails confirm option to SlatAction.
+          # Passes in the rails confirm option to the slat action component.
           # Rails example: link_to 'Delete', ..., confirm: 'Are you sure?'
           def confirm
             options.fetch(:confirm, nil)
           end
 
           # Passes the :disable_with option, when present, to the
-          # integrated SlatAction -- this adds the rails disable_with
+          # integrated slat action component -- this adds the rails disable_with
           # Rails example: link_to 'Delete', ..., disable_with: 'Deleting...'
           def disable_with
             options.fetch(:disable_with, nil)
@@ -64,7 +65,7 @@ module NfgUi
             options[:href] || '#'
           end
 
-          # Passes in the rails confirm option to SlatAction.
+          # Passes in the rails confirm option to the slat action component.
           # Rails example: link_to 'Update', ..., method: :patch
           def method
             options.fetch(:method, nil)
@@ -77,7 +78,7 @@ module NfgUi
             options[:outlined] || button
           end
 
-          # Passes in the rails :remote option to SlatAction
+          # Passes in the rails :remote option to the slat action component
           # Rails example: link_to 'Get Started', remote: true
           def remote
             options.fetch(:remote, nil)
@@ -89,7 +90,7 @@ module NfgUi
 
           # Passes the standard `:theme` option to the integrated Slat Action
           #
-          # When the SlatAction is a `button` (`button: true`):
+          # When the slat action component is a `button` (`button: true`):
           # The integrated slat action will default to the `:secondary` theme
           # per the design system style guide.
           #
@@ -113,7 +114,7 @@ module NfgUi
 
           # Supplies the SlatActions with
           # the appropriate css classes for the action link
-          # when the SlatActions is used to bypass writing a manual SlatAction
+          # when the SlatActions is used to bypass writing a manual slat action component
           # This is complicated, and thus...
           # This is why we are creating a patching module -- so that we can later rip this stuff out.
           def integrated_slat_action_link_css_classes
@@ -123,7 +124,7 @@ module NfgUi
             ].join(' ').squish
           end
 
-          # Determines if the integrated SlatAction is a delete link
+          # Determines if the slat action component is a delete link
           # Evaluated by examining the :method option
           #
           # This is used to determine where to inject the `delete` HTML data attribute (data-method)
@@ -132,9 +133,9 @@ module NfgUi
             @delete_link ||= options.fetch(:method, nil) == :delete
           end
 
-          # When the integrated SlatAction is a button component,
+          # When the slat action component is a button component,
           # These are the compiled options that are passed
-          # through from the SlatActions options into the SlatAction (now, button) options.
+          # through from the SlatActions options into the integrated button's options.
           #
           # This also acts as a filter against what is allowed to pass
           # and what is not allowed to pass into the
@@ -175,8 +176,8 @@ module NfgUi
               confirm: confirm }.merge(mergable_delete_link)
           end
 
-          # The HTML options that are passed into the manually created SlatAction
-          # For instances where you are bypassing the manual SlatAction by leveraging the
+          # The HTML options that are passed into the manually created slat action component
+          # For instances where you are bypassing the manual slat action component by leveraging the
           def integrated_slat_action_html_options
           { href: href,
             class: integrated_slat_action_link_css_classes,
@@ -187,7 +188,7 @@ module NfgUi
 
           # These options are removed from attributes because
           # they are picked up and placed on the *SlatActions*
-          # and not on the integrated *SlatAction*
+          # and not on the integrated *slat action component*
           def non_html_attribute_options
             super.push(:button, :confirm, :disable_with, :href, :method, :remote, :theme)
           end

--- a/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
+++ b/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
@@ -70,6 +70,13 @@ module NfgUi
             options.fetch(:method, nil)
           end
 
+          # Allow for outline settings to be added
+          # Assumes true if `button: true` per design system
+          # style guide expectations.
+          def outlined
+            options[:outlined] || button
+          end
+
           # Passes in the rails :remote option to SlatAction
           # Rails example: link_to 'Get Started', remote: true
           def remote
@@ -77,18 +84,7 @@ module NfgUi
           end
 
           def render_integrated_slat_action
-            if button
-              # raise integrated_slat_action_button_component_options.inspect
-              NfgUi::Components::Elements::Button.new({ **integrated_slat_action_button_component_options, body: (block_given? ? yield : body) }, view_context).render
-            else
-              content_tag(:a, **integrated_slat_action_html_options) do
-                if icon
-                  NfgUi::Components::Foundations::Icon.new({ traits: [icon], text: (block_given? ? yield : body), theme: theme }, view_context).render
-                else
-                  (block_given? ? yield : body)
-                end
-              end
-            end
+            button ? render_button : render_link
           end
 
           # Passes the standard `:theme` option to the integrated Slat Action
@@ -196,11 +192,20 @@ module NfgUi
             super.push(:button, :confirm, :disable_with, :href, :method, :remote, :theme)
           end
 
-          # Allow for outline settings to be added
-          # Assumes true if `button: true` per design system
-          # style guide expectations.
-          def outlined
-            options.fetch(:outlined, button)
+          # When `:button` is `true`, this is what is rendered
+          def render_button
+            NfgUi::Components::Elements::Button.new({ **integrated_slat_action_button_component_options, body: (block_given? ? yield : body) }, view_context).render
+          end
+
+          # When `:button` is `false`, a link is rendered
+          def render_link
+            content_tag(:a, **integrated_slat_action_html_options) do
+              if icon
+                NfgUi::Components::Foundations::Icon.new({ traits: [icon], text: (block_given? ? yield : body), theme: theme }, view_context).render
+              else
+                (block_given? ? yield : body)
+              end
+            end
           end
         end
       end

--- a/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
+++ b/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+# This module should be removed upon re-evaluation of Slat components.
+module NfgUi
+  module Components
+    module Utilities
+      module Patches
+        # Terminology:
+        # SlatAction  - is the equivalent of a dropdown menu item
+        # SlatActions - is the parent / wrapping component of the SlatAction(s)
+        #
+        # Usage: When you are creating a slat that does not need a menu but has a singular action link
+        # For example: when the only option you have on a slat is to delete that item.
+        #
+        # This module allows you to pass in options that will
+        # automatically generate a slat action for you
+        # ... without having to manually add a slat_action to your code.
+        #
+        # Example usage:
+        # = ui.nfg :slat_actions, menu: false, icon: 'trash', body: 'Delete', href: '#nogo'
+        #
+        # The above will automatically generate a slat action so you
+        # do not need to add a slat action in the slat_actions (note: plural slat_actions)
+        #
+        # This is a monkeypatch while we re-evaluate the Slat component suite
+        # so as not to break existing code implementation on our apps.
+        module IntegratedSlatAction
+          # Allows for icons to be passed into the integrated SlatAction
+          include NfgUi::Components::Utilities::Iconable
+
+          # Allows for using theme traits on the SlatActions component
+          # that is then passed through to the integrated slat action.
+          # Note:
+          include NfgUi::Components::Traits::Theme
+
+          # This sets whether or not the SlatAction is a button.
+          # If it's not a button, the integrated slat action
+          # is rendered via a content_tag as a normal link.
+          #
+          # If it is a button, the integrated slat action
+          # is rendered as a button component
+          # (NfgUi::Components::Elements::Button)
+          def button
+            options.fetch(:button, false)
+          end
+
+          # Passes in the rails confirm option to SlatAction.
+          # Rails example: link_to 'Delete', ..., confirm: 'Are you sure?'
+          def confirm
+            options.fetch(:confirm, nil)
+          end
+
+          # Passes the :disable_with option, when present, to the
+          # integrated SlatAction -- this adds the rails disable_with
+          # Rails example: link_to 'Delete', ..., disable_with: 'Deleting...'
+          def disable_with
+            options.fetch(:disable_with, nil)
+          end
+
+          # Sets a fallback for href so that
+          # integrated action items are still
+          # correctly styled
+          def href
+            options[:href] || '#'
+          end
+
+          # Passes in the rails confirm option to SlatAction.
+          # Rails example: link_to 'Update', ..., method: :patch
+          def method
+            options.fetch(:method, nil)
+          end
+
+          # Passes in the rails :remote option to SlatAction
+          # Rails example: link_to 'Get Started', remote: true
+          def remote
+            options.fetch(:remote, nil)
+          end
+
+          def render_integrated_slat_action
+            if button
+              # raise integrated_slat_action_button_component_options.inspect
+              NfgUi::Components::Elements::Button.new({ **integrated_slat_action_button_component_options, body: (block_given? ? yield : body) }, view_context).render
+            else
+              content_tag(:a, **integrated_slat_action_html_options) do
+                if icon
+                  NfgUi::Components::Foundations::Icon.new({ traits: [icon], text: (block_given? ? yield : body), theme: theme }, view_context).render
+                else
+                  (block_given? ? yield : body)
+                end
+              end
+            end
+          end
+
+          # Passes the standard `:theme` option to the integrated Slat Action
+          #
+          # When the SlatAction is a `button` (`button: true`):
+          # The integrated slat action will default to the `:secondary` theme
+          # per the design system style guide.
+          #
+          # The default `:secondary` theme can be manually overridden by passing in a
+          # `:theme` trait or `:theme` option to the parent SlatActions component.
+          def theme
+            # Note: this needs to be solved / addressed
+            # For whatever reason, the traits are not being picked up by the
+            # button version of the slat action.
+            # This ensures that any theme traits get applied here.
+            # calculated_theme = (traits & NfgUi::Components::Traits::Theme::COLOR_TRAITS)
+
+            # calculated_theme.any? ? calculated_theme.first : options[:theme]
+            # raise options.inspect
+            # options[:theme]
+            # options.fetch(:theme, super)
+            options.fetch(:theme, nil)
+          end
+
+          private
+
+          # Supplies the SlatActions with
+          # the appropriate css classes for the action link
+          # when the SlatActions is used to bypass writing a manual SlatAction
+          # This is complicated, and thus...
+          # This is why we are creating a patching module -- so that we can later rip this stuff out.
+          def integrated_slat_action_link_css_classes
+            [
+              ("text-#{theme}" if theme),
+              'd-block'
+            ].join(' ').squish
+          end
+
+          # Determines if the integrated SlatAction is a delete link
+          # Evaluated by examining the :method option
+          #
+          # This is used to determine where to inject the `delete` HTML data attribute (data-method)
+          # and value ('delete') in the integrated slat action's HTML options
+          def delete_link?
+            @delete_link ||= options.fetch(:method, nil) == :delete
+          end
+
+          # When the integrated SlatAction is a button component,
+          # These are the compiled options that are passed
+          # through from the SlatActions options into the SlatAction (now, button) options.
+          #
+          # This also acts as a filter against what is allowed to pass
+          # and what is not allowed to pass into the
+          # integrated component.
+          def integrated_slat_action_button_component_options
+            # Do not set theme to nil (so theme defaults will run)
+            # Instead, do not pass in a theme at all.
+            # theme_options_hash = theme ? { theme: theme } : {}
+
+            { theme: (theme || :secondary),
+              # **theme_options_hash,
+              traits: traits,
+              as: :a,
+              confirm: confirm,
+              disable_with: disable_with,
+              href: href,
+              method: send(:method),
+              remote: remote,
+              outlined: outlined,
+              icon: icon }
+          end
+
+          # Given the complexity of the data-attributes,
+          # this isolates them into their own method for ease
+          # of following what's going on.
+          #
+          # Essentially, since the :delete method is actually
+          # converted to a data-attribute in rails, we
+          # have to manually merge the `data-method='delete'` into the data attributes hash
+          #
+          # This brings the whole data-attributes suite together
+          # and optionally merges in the data-method='delete' if
+          # this is a delete button/link.
+          def integrated_slat_action_html_data_attributes
+            mergable_delete_link = delete_link? ? { method: :delete } : {}
+
+            { disable_with: disable_with,
+              confirm: confirm }.merge(mergable_delete_link)
+          end
+
+          # The HTML options that are passed into the manually created SlatAction
+          # For instances where you are bypassing the manual SlatAction by leveraging the
+          def integrated_slat_action_html_options
+          { href: href,
+            class: integrated_slat_action_link_css_classes,
+            method: send(:method),
+            remote: remote,
+            data: integrated_slat_action_html_data_attributes }
+          end
+
+          # These options are removed from attributes because
+          # they are picked up and placed on the *SlatActions*
+          # and not on the integrated *SlatAction*
+          def non_html_attribute_options
+            super.push(:button, :confirm, :disable_with, :href, :method, :remote, :theme)
+          end
+
+          # Allow for outline settings to be added
+          # Assumes true if `button: true` per design system
+          # style guide expectations.
+          def outlined
+            options.fetch(:outlined, button)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.8.17'
+  VERSION = '0.9.8.18'
 end

--- a/nfg_ui.gemspec
+++ b/nfg_ui.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'bootstrap', '4.3.1'
   s.add_dependency 'coffee-script', '~> 2.4'
   s.add_dependency 'font-awesome-rails', '~> 4.7'
-  s.add_dependency 'haml', '~> 5.0'
   s.add_dependency 'inky-rb', '~> 1.3.7'
   s.add_dependency 'jquery-rails', '~> 4.3'
   s.add_dependency 'rails', '>= 4.2.0'

--- a/spec/lib/nfg_ui/components/patterns/slat_actions_spec.rb
+++ b/spec/lib/nfg_ui/components/patterns/slat_actions_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe NfgUi::Components::Patterns::SlatActions do
+  # This utility is consumed by SlatAction
+  let(:options) { {} }
+  let(:view_context) { ActionController::Base.new.view_context }
+  let(:slat_actions) { described_class.new(options, view_context) }
+
+
+  describe 'the rendered HTML' do
+    let(:options) { {} }
+    subject { slat_actions.render }
+
+    it 'renders the component' do
+      expect(subject).to eq "<div class=\"slat-actions\" href=\"#\"><div class=\"dropdown\"><button class=\"btn dropdown-toggle btn-outline-secondary\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\" type=\"button\">Actions<i class=\"fa fa-caret-down ml-1 ml-1\"></i></button><div class=\"dropdown-menu dropdown-menu-right\"></div></div></div>"
+    end
+  end
+
+  describe '#component_family' do
+    subject { slat_actions.component_family }
+    it { is_expected.to eq :slats }
+  end
+
+  describe '#menu' do
+    let(:options) { { menu: tested_menu } }
+    let(:tested_menu) { nil }
+
+    subject { slat_actions.menu }
+
+    context 'when :menu is present in the options' do
+      let(:tested_menu) { true }
+      it { is_expected.to eq tested_menu }
+    end
+
+    context 'when :menu is not present in the options' do
+      let(:options) { {} }
+      it { is_expected.to be }
+    end
+  end
+
+  describe '#slat_header' do
+    let(:options) { { slat_header: tested_slat_header } }
+    let(:tested_slat_header) { nil }
+
+    subject { slat_actions.slat_header }
+
+    context 'when :slat_header is present in the options' do
+      let(:tested_slat_header) { true }
+      it { is_expected.to eq tested_slat_header }
+    end
+
+    context 'when :slat_header is not present in the options' do
+      let(:options) { {} }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#wide' do
+    let(:options) { { wide: tested_wide } }
+    let(:tested_wide) { nil }
+
+    subject { slat_actions.wide }
+
+    context 'when :wide is present in the options' do
+      let(:tested_wide) { true }
+      it { is_expected.to eq tested_wide }
+    end
+
+    context 'when :wide is not present in the options' do
+      let(:options) { {} }
+      it { is_expected.to be }
+    end
+  end
+
+  describe '#render' do
+    subject { slat_actions.render }
+
+    context 'when :menu is true in options' do
+      let(:options) { { menu: true, **additional_options } }
+      let(:additional_options) { {} }
+
+      context 'and when :slat_header is true in options' do
+        let(:additional_options) { { slat_header: true } }
+        it 'renders the slat header version of the slat actions component' do
+          expect(subject).to eq "<div class=\"slat-actions\" href=\"#\"><h6 class=\"display-4\">&nbsp;</h6></div>"
+        end
+      end
+
+      context 'and when :slat_header is falsey in options' do
+        it 'renders the full component' do
+          by 'rendering the slat actions within the dropdown menu' do
+            expect(subject).to include "<div class=\"slat-actions\" href=\"#\"><div class=\"dropdown\">"
+          end
+
+          and_by 'rendering the secondary outlined dropdown toggle' do
+            expect(subject).to include "<button class=\"btn dropdown-toggle btn-outline-secondary\" data-toggle=\"dropdown\""
+          end
+
+          and_by 'rendering the default language for the action menu' do
+            expect(subject).to include "Actions<i class=\"fa fa-caret-down ml-1 ml-1\"></i>"
+          end
+
+          and_by 'rendering the dropdown menu on the right' do
+            expect(subject).to include "<div class=\"dropdown-menu dropdown-menu-right\">"
+          end
+        end
+      end
+    end
+
+    # This is extensively tested in
+    # spec/lib/nfg_ui/components/utilities/patches/integrated_slat_action_spec.rb
+    context 'when :menu is false' do
+      let(:options) { { menu: false } }
+      it { is_expected.to include slat_actions.send(:render_integrated_slat_action) }
+    end
+  end
+
+  describe 'private methods' do
+    describe '#css_classes' do
+      subject { slat_actions.send(:css_classes) }
+
+      context 'when :wide is true in options' do
+        let(:options) { { wide: true } }
+        it { is_expected.not_to include 'slat-actions-sm' }
+      end
+
+      context 'when :wide is falsey in options' do
+        let(:options) { { wide: false } }
+        it { is_expected.to include 'slat-actions-sm' }
+      end
+    end
+  end
+end

--- a/spec/lib/nfg_ui/components/utilities/patches/integrated_slat_action_spec.rb
+++ b/spec/lib/nfg_ui/components/utilities/patches/integrated_slat_action_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe NfgUi::Components::Utilities::Patches::IntegratedSlatAction do
   let(:view_context) { ActionController::Base.new.view_context }
   let(:slat_actions) { NfgUi::Components::Patterns::SlatActions.new(options, view_context) }
 
+  # Have to run these against SlatActions since it's included in the SlatActions class
+  describe 'included modules' do
+    let(:described_class) { NfgUi::Components::Patterns::SlatActions }
+    it_behaves_like 'a component that includes the Iconable utility module'
+  end
+
   describe '#button' do
     let(:tested_button) { nil }
     let(:options) { { button: tested_button } }

--- a/spec/lib/nfg_ui/components/utilities/patches/integrated_slat_action_spec.rb
+++ b/spec/lib/nfg_ui/components/utilities/patches/integrated_slat_action_spec.rb
@@ -1,0 +1,243 @@
+require 'rails_helper'
+
+RSpec.describe NfgUi::Components::Utilities::Patches::IntegratedSlatAction do
+  # This utility is consumed by SlatAction
+  let(:options) { {} }
+  let(:view_context) { ActionController::Base.new.view_context }
+  let(:slat_actions) { NfgUi::Components::Patterns::SlatActions.new(options, view_context) }
+
+  describe '#button' do
+    let(:tested_button) { nil }
+    let(:options) { { button: tested_button } }
+    subject { slat_actions.button }
+
+    context 'when button is present in options' do
+      let(:tested_button) { true }
+      it { is_expected.to be }
+    end
+
+    context 'when button is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#confirm' do
+    let(:tested_confirm) { nil }
+    let(:options) { { confirm: tested_confirm } }
+    subject { slat_actions.confirm }
+
+    context 'when confirm is present in options' do
+      let(:tested_confirm) { true }
+      it { is_expected.to be }
+    end
+
+    context 'when confirm is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#disable_with' do
+    let(:tested_disable_with) { nil }
+    let(:options) { { disable_with: tested_disable_with } }
+    subject { slat_actions.disable_with }
+
+    context 'when disable_with is present in options' do
+      let(:tested_disable_with) { 'test' }
+      it { is_expected.to eq tested_disable_with }
+    end
+
+    context 'when disable_with is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#href' do
+    let(:tested_href) { nil }
+    let(:options) { { href: tested_href } }
+    subject { slat_actions.href }
+
+    context 'when href is present in options' do
+      let(:tested_href) { '#test' }
+      it { is_expected.to eq tested_href }
+    end
+
+    context 'when href is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to eq '#' }
+    end
+
+    context 'when href is nil in options' do
+      let(:tested_href) { nil }
+      it { is_expected.to eq '#' }
+    end
+  end
+
+  describe '#method' do
+    let(:tested_method) { nil }
+    let(:options) { { method: tested_method } }
+    subject { slat_actions.send(:method) }
+
+    context 'when method is present in options' do
+      let(:tested_method) { :patch }
+      it { is_expected.to eq tested_method }
+    end
+
+    context 'when method is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#outlined' do
+    subject { slat_actions.outlined }
+    let(:options) { {} }
+
+    context 'when :outlined is present in options' do
+      let(:tested_outline) { true }
+      let(:options) { { outlined: tested_outline } }
+      it { is_expected.to eq tested_outline }
+    end
+
+    context 'when :outlined is not present in options' do
+      context 'and when :button is present in options' do
+        let(:options) { { button: tested_button } }
+        let(:tested_button) { true }
+        it { is_expected.to eq tested_button }
+      end
+
+      context 'and when :button is not present in options' do
+        let(:options) { {} }
+        it { is_expected.not_to be }
+      end
+
+    end
+
+  end
+
+  describe '#remote' do
+    let(:tested_remote) { nil }
+    let(:options) { { remote: tested_remote } }
+    subject { slat_actions.remote }
+
+    context 'when remote is present in options' do
+      let(:tested_remote) { true }
+      it { is_expected.to be }
+    end
+
+    context 'when remote is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#render_integrated_slat_action' do
+    let(:options) { { button: tested_button } }
+    subject { slat_actions.render_integrated_slat_action }
+
+    context 'when :button is true in options' do
+      let(:tested_button) { true }
+      it 'renders a button component' do
+        expect(subject).to eq "<a class=\"btn btn-outline-secondary\" href=\"#\"></a>"
+      end
+    end
+
+    context 'when :button is falsey' do
+      let(:tested_button) { false }
+      it 'renders a link' do
+        expect(subject).to eq "<a href=\"#\" class=\"d-block\"></a>"
+      end
+    end
+  end
+
+  describe '#theme' do
+    let(:tested_theme) { nil }
+    let(:options) { { theme: tested_theme } }
+    subject { slat_actions.theme }
+
+    context 'when theme is present in options' do
+      let(:tested_theme) { :danger }
+      it { is_expected.to eq tested_theme }
+    end
+
+    context 'when theme is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe 'private methods' do
+    describe '#integrated_slat_action_link_css_classes' do
+      subject { slat_actions.send(:integrated_slat_action_link_css_classes) }
+
+      it { is_expected.to include 'd-block' }
+
+      context 'when theme is present' do
+        let(:options) { { theme: tested_theme } }
+        let(:tested_theme) { :danger }
+        it { is_expected.to eq "text-#{tested_theme.to_s} d-block" }
+      end
+
+      context 'when theme is not present' do
+        let(:options) { {} }
+        it { is_expected.not_to include "text" }
+        it { is_expected.to eq 'd-block' }
+      end
+    end
+
+    describe '#delete_link?' do
+      subject { slat_actions.send(:delete_link?) }
+
+      context 'when :method is present in options' do
+        let(:options) { { method: tested_method } }
+
+        context 'when :method is :delete' do
+          let(:tested_method) { :delete }
+          it { is_expected.to be }
+        end
+
+        context 'when :method is not :delete' do
+          let(:tested_method) { :patch }
+          it { is_expected.not_to be }
+        end
+      end
+
+      context 'when :method is not present in options' do
+        let(:options) { {} }
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    describe '#integrated_slat_action_html_data_attributes' do
+      let(:options) { { method: tested_method, disable_with: tested_disable_with, confirm: tested_confirm } }
+      let(:tested_method) { nil }
+      let(:tested_disable_with) { nil }
+      let(:tested_confirm) { nil }
+
+      subject { slat_actions.send(:integrated_slat_action_html_data_attributes) }
+
+      context 'when the the options include method: :delete' do
+        let(:tested_method) { :delete }
+        it { is_expected.to include({ method: :delete }) }
+        it { expect(subject.keys).to include :method }
+      end
+
+      context 'when the options do not include method: :delete' do
+        let(:tested_method) { :patch }
+        it { expect(subject.keys).not_to include :method }
+      end
+    end
+
+    describe '#render_button' do
+      subject { slat_actions.send(:render_button) }
+      it { is_expected.to eq "<a class=\"btn btn-secondary\" href=\"#\"></a>" }
+    end
+
+    describe '#render_link' do
+      subject { slat_actions.send(:render_link) }
+      it { is_expected.to eq "<a href=\"#\" class=\"d-block\"></a>" }
+    end
+  end
+end

--- a/spec/shared_examples/components/traits/theme_traits_shared_examples.rb
+++ b/spec/shared_examples/components/traits/theme_traits_shared_examples.rb
@@ -10,11 +10,13 @@ shared_examples_for 'a component that includes the Theme trait module' do |test_
                                       :warning_trait,
                                       :info_trait,
                                       :light_trait,
-                                      :dark_trait)
+                                      :dark_trait,
+                                      :white_trait,
+                                      :outlined_trait)
     end
 
     describe 'registered traits' do
-      it { expect(NfgUi::Components::Traits::Theme::TRAITS).to eq %i[primary secondary success danger warning info light dark outlined] }
+      it { expect(NfgUi::Components::Traits::Theme::TRAITS).to eq %i[primary secondary success danger warning info light dark white outlined] }
     end
 
     describe 'trait updates to components' do
@@ -23,52 +25,16 @@ shared_examples_for 'a component that includes the Theme trait module' do |test_
       let(:tested_trait) { nil }
       let(:ruby_component) { described_class.new(options, ActionController::Base.new.view_context) }
 
-      describe 'options updated for the ruby component from traits' do
-        describe ':primary trait' do
-          let(:tested_trait) { :primary }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':secondary trait' do
-          let(:tested_trait) { :secondary }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':secondary trait' do
-          let(:tested_trait) { :success }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':secondary trait' do
-          let(:tested_trait) { :danger }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':warning trait' do
-          let(:tested_trait) { :danger }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':info trait' do
-          let(:tested_trait) { :danger }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':light trait' do
-          let(:tested_trait) { :danger }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':dark trait' do
-          let(:tested_trait) { :danger }
-          it { expect(ruby_component.theme).to eq tested_trait }
-        end
-
-        describe ':outlined trait' do
-          let(:tested_trait) { :outlined }
-          it { expect(ruby_component.options[:outlined]).to be true }
-        end
-      end
+      # describe 'options updated for the ruby component from traits' do
+      #   it 'updates the color theme correctly' do
+      #     # by 'confirming the trait updates the theme for the uniquely rendered component' do
+      #       NfgUi::Components::Traits::Theme::COLOR_TRAITS.each do |theme_trait_name|
+      #         themed_component = described_class.new({ traits: [theme_trait_name] }, ActionController::Base.new.view_context)
+      #         expect(themed_component.theme).to eq theme_trait_name
+      #       end
+      #     # end
+      #   end
+      # end
 
       # Some components utilize the thematic trait (without themeable utility module)
       # to be able to pass the requested theme down to a child component
@@ -94,48 +60,54 @@ shared_examples_for 'a component that includes the Theme trait module' do |test_
                 it_behaves_like 'a thematic color trait'
               end
 
-              describe ':secondary trait' do
+              describe ':success trait' do
                 let(:tested_trait) { :success }
                 it { expect(ruby_component.theme).to eq tested_trait }
                 it_behaves_like 'a thematic color trait'
               end
 
-              describe ':secondary trait' do
+              describe ':danger trait' do
                 let(:tested_trait) { :danger }
                 it { expect(ruby_component.theme).to eq tested_trait }
                 it_behaves_like 'a thematic color trait'
               end
 
               describe ':warning trait' do
-                let(:tested_trait) { :danger }
+                let(:tested_trait) { :warning }
                 it { expect(ruby_component.theme).to eq tested_trait }
                 it_behaves_like 'a thematic color trait'
               end
 
               describe ':info trait' do
-                let(:tested_trait) { :danger }
+                let(:tested_trait) { :info }
                 it { expect(ruby_component.theme).to eq tested_trait }
                 it_behaves_like 'a thematic color trait'
               end
 
               describe ':light trait' do
-                let(:tested_trait) { :danger }
+                let(:tested_trait) { :light }
                 it { expect(ruby_component.theme).to eq tested_trait }
                 it_behaves_like 'a thematic color trait'
               end
 
               describe ':dark trait' do
-                let(:tested_trait) { :danger }
+                let(:tested_trait) { :dark }
+                it { expect(ruby_component.theme).to eq tested_trait }
+                it_behaves_like 'a thematic color trait'
+              end
+
+              describe ':white trait' do
+                let(:tested_trait) { :white }
                 it { expect(ruby_component.theme).to eq tested_trait }
                 it_behaves_like 'a thematic color trait'
               end
             end
 
             context 'and when a component does have the additional :outlined trait' do
-              let(:themes) { %i[primary secondary success danger warning info light dark] }
+              let(:themes) { NfgUi::Components::Traits::Theme::COLOR_TRAITS }
               let(:traits) { [@theme, :outlined] }
 
-              %i[primary secondary success danger warning info light dark].each do |theme|
+              NfgUi::Components::Traits::Theme::COLOR_TRAITS.each do |theme|
                 it 'applies the theme with the outlined variation' do
                   @theme = theme
                   if ruby_component.send(:outlineable?)

--- a/spec/test_app/app/views/patterns/slats/index.html.haml
+++ b/spec/test_app/app/views/patterns/slats/index.html.haml
@@ -1,3 +1,40 @@
+.text-right
+  ":warning trait (button)"
+  %br
+  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: true
+
+  -#
+    / %br
+    / = NfgUi::Components::Elements::Button.new({traits: [:warning], body: 'sup'}, self).theme.inspect
+    / %br
+    / = NfgUi::Components::Elements::Button.new({traits: [:warning], body: 'sup'}, self).render.inspect
+
+  %p.my-3
+  "Theme: :danger (button)"
+  %br
+  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo', button: true
+  %p.my-3
+  "No theme (button)"
+  %br
+  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', button: true
+
+  %p.my-3
+  ":warning trait (not button)"
+  %br
+  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: false
+  %p.my-3
+  "theme: :danger (not button)"
+  %br
+  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo'
+
+  %p.my-3
+  "no theme"
+  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo'
+
+
+%hr
+%p.my-5
+
 %h1 Slats
 
 %h2.mb-4 Manual build
@@ -52,7 +89,7 @@
   = ui.nfg :slat_list do
     = ui.nfg :slat do
       = ui.nfg :slat_body do
-        
+
         = ui.nfg :slat_item, heading: 'Non-wide slat set on slat_actions (wide: false)'
         = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
 
@@ -86,14 +123,21 @@
   = ui.nfg :slat_list do
     = ui.nfg :slat do
       = ui.nfg :slat_body do
-        
+
         = ui.nfg :slat_item, heading: 'Slat information'
         = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
 
       = ui.nfg :slat_actions, menu: false, icon: 'trash', body: 'Delete', href: '#nogo'
     = ui.nfg :slat do
       = ui.nfg :slat_body do
-        
+
+        = ui.nfg :slat_item, heading: 'Button version'
+        = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
+
+      = ui.nfg :slat_actions, menu: false, icon: 'trash', body: 'Button', href: '#nogo', button: true
+    = ui.nfg :slat do
+      = ui.nfg :slat_body do
+
         = ui.nfg :slat_item, heading: 'Slat information'
         = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
 
@@ -116,7 +160,14 @@
   = ui.nfg :slat_list do
     = ui.nfg :slat do
       = ui.nfg :slat_body do
-        
+
+        = ui.nfg :slat_item, heading: 'Button version of slat action'
+        = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
+
+      = ui.nfg :slat_actions, button: true, menu: false, icon: 'trash', href: '#nogo'
+    = ui.nfg :slat do
+      = ui.nfg :slat_body do
+
         = ui.nfg :slat_item, heading: 'Slat information'
         = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
 
@@ -124,11 +175,19 @@
 
     = ui.nfg :slat do
       = ui.nfg :slat_body do
-        
+
         = ui.nfg :slat_item, heading: 'Slat information'
         = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
 
       = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', method: :get, disable_with: 'Disabler', confirm: 'Are you sure?'
+
+    = ui.nfg :slat do
+      = ui.nfg :slat_body do
+
+        = ui.nfg :slat_item, heading: 'Button version of slat action'
+        = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
+
+      = ui.nfg :slat_actions, button: true, menu: false, icon: 'trash', href: '#nogo'
 
 .row
   .col-md-6.col-8.mx-auto
@@ -143,7 +202,7 @@
       = ui.nfg :slat_list do
         = ui.nfg :slat do
           = ui.nfg :slat_body do
-            
+
             = ui.nfg :slat_item, heading: 'Slat information'
             = ui.nfg :slat_item, heading: '$5000', class: 'text-right', caption: 'An amount caption'
 
@@ -151,13 +210,13 @@
 
         = ui.nfg :slat do
           = ui.nfg :slat_body do
-            
+
             = ui.nfg :slat_item, heading: 'Slat information'
             = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
 
           = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', method: :get, disable_with: 'Disabler', confirm: 'Are you sure?'
 
-  
+
 
 .mt-5
 %hr
@@ -175,11 +234,19 @@
   = ui.nfg :slat_list do
     = ui.nfg :slat do
       = ui.nfg :slat_body do
-        
+
         = ui.nfg :slat_item, :lg, heading: 'Slat information (:lg)'
         = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
 
       = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo'
+
+    = ui.nfg :slat do
+      = ui.nfg :slat_body do
+
+        = ui.nfg :slat_item, :lg, heading: 'Slat information (:lg) button version'
+        = ui.nfg :slat_item, heading: '$5000', caption: 'An amount caption'
+
+      = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: true
 
 .mt-5
 %hr

--- a/spec/test_app/app/views/patterns/slats/index.html.haml
+++ b/spec/test_app/app/views/patterns/slats/index.html.haml
@@ -1,35 +1,3 @@
-.text-right
-  ":warning trait (button)"
-  %br
-  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: true
-
-  -#
-    / %br
-    / = NfgUi::Components::Elements::Button.new({traits: [:warning], body: 'sup'}, self).theme.inspect
-    / %br
-    / = NfgUi::Components::Elements::Button.new({traits: [:warning], body: 'sup'}, self).render.inspect
-
-  %p.my-3
-  "Theme: :danger (button)"
-  %br
-  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo', button: true
-  %p.my-3
-  "No theme (button)"
-  %br
-  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', button: true
-
-  %p.my-3
-  ":warning trait (not button)"
-  %br
-  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: false
-  %p.my-3
-  "theme: :danger (not button)"
-  %br
-  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo'
-
-  %p.my-3
-  "no theme"
-  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo'
 
 
 %hr
@@ -264,3 +232,33 @@
     = ui.nfg :slat do
       = ui.nfg :slat_body do
         = ui.nfg :slat_item, heading: 'Your shopping cart'
+
+%hr
+
+%h3.my-4 Slat Actions that build a slat action on their own
+.text-right
+  ":warning trait (button)"
+  %br
+  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: true
+
+  %p.my-3
+  "Theme: :danger (button)"
+  %br
+  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo', button: true
+  %p.my-3
+  "No theme (button)"
+  %br
+  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', button: true
+
+  %p.my-3
+  ":warning trait (not button)"
+  %br
+  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: false
+  %p.my-3
+  "theme: :danger (not button)"
+  %br
+  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo'
+
+  %p.my-3
+  "no theme"
+  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo'


### PR DESCRIPTION
**Initiative:** Slat upgrades feature

1. SlatActions (`ui.nfg :slat_actions`) needed a `:button` option (to turn the integrated slat action into a button when `:menu` is `false`)
2. Isolate the integrated slat action methods so they can be easily removed later... In an effort to reduce clutter and signal that this slat actions component is in a patched state ahead of re-evaluation of the slats component suite.
3. Update some CSS styles needed for slats.

Solution suite:
* Created a new utility module under a folder called `patches` for `IntegrateSlatAction`.
* Move all of the methods out of `SlatActions` that were designed to generate the integrated slat action.
* Break apart really complex methods into smaller more manageable code.
* Add the `:button` option to the `SlatActions` and update the render code to implement a button more cleanly.
* Include the module into SlatActions so we can rip it out later.
* Updated example documentation for slats.