### PR TITLE
Updates icons to sit on the left side instead of the right side.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 # 0.9.9
 *Non-breaking changes*
-* SlatActions can now accept the :button option.
+* `SlatActions` can now accept the `:button` option.
   * Example usage: `= ui.nfg :slat_actions, icon: 'trash', body: 'Delete', menu: false, button: true`
 * A patching system has been introduced for the design system (not `bootstrap`).
   * Patching a component will now signal that we are introducing functionality that we intend to remove. It also provides a pattern for implementing "quick fixes" and provides a single module suite to review for code debt.
 * Along with the patching concept, a new pattern for "quick built" components is now available. This allows us to remove "pass through" methods from the parent component's class and keep it in its own isolated area.
-  * For now, this lives in the "Patching" folder, but will eventually be moved when further adopted since this particular implementation is a signal of code debt.
+  * For now, this lives in the `lib/nfg_ui/components/utilities/patches/` folder, but will eventually be moved out of patches when further adopted for _other_ components since this particular implementation for `SlatActions` is a signal of code debt.
   * The module name will use a naming convention as such:
     * `Integrated` indicating it is integrated in some way into the component's rendering.
     * `SpiritualChildComponent` class name (ex: `SlatAction`)
-    * The actual component implemented is not necessarily important. In the `IntegratedSlatAction` module, we actually leverage both a text link and a `Button` component. Neither of which calls the actual SlatAction component. While this may change later depending how we handle the evolution of our most complex component suite... *slats*, *the most important point is to signal* what this is being integrated _as_* Thus, The `IntegratedSlatAction` is communicated as a "slat action" integrated into this component. Nifty.
-* CSS improvements introduced for the slat actions.
+    * The actual component implemented is not necessarily important. In the `IntegratedSlatAction` module, we actually leverage both a text link and a `Button` component. Neither of which calls the actual SlatAction component. While this may change later depending how we handle the evolution of our most complex component suite... *slats. The most important point is to signal* what this sub component is being integrated *_as_* Thus, The `IntegratedSlatAction` is communicated as a "slat action" integrated into this component. Nifty.
+* CSS improvements introduced for `SlatItem` fixing a spacing bug for small slat items.
 
 # <= 0.9.8.18
 * Not documented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+# 0.9.9
+*Non-breaking changes*
+* SlatActions can now accept the :button option.
+  * Example usage: `= ui.nfg :slat_actions, icon: 'trash', body: 'Delete', menu: false, button: true`
+* A patching system has been introduced for the design system (not `bootstrap`).
+  * Patching a component will now signal that we are introducing functionality that we intend to remove. It also provides a pattern for implementing "quick fixes" and provides a single module suite to review for code debt.
+* Along with the patching concept, a new pattern for "quick built" components is now available. This allows us to remove "pass through" methods from the parent component's class and keep it in its own isolated area.
+  * For now, this lives in the "Patching" folder, but will eventually be moved when further adopted since this particular implementation is a signal of code debt.
+  * The module name will use a naming convention as such:
+    * `Integrated` indicating it is integrated in some way into the component's rendering.
+    * `SpiritualChildComponent` class name (ex: `SlatAction`)
+    * The actual component implemented is not necessarily important. In the `IntegratedSlatAction` module, we actually leverage both a text link and a `Button` component. Neither of which calls the actual SlatAction component. While this may change later depending how we handle the evolution of our most complex component suite... *slats*, *the most important point is to signal* what this is being integrated _as_* Thus, The `IntegratedSlatAction` is communicated as a "slat action" integrated into this component. Nifty.
+* CSS improvements introduced for the slat actions.
+
+# <= 0.9.8.18
+* Not documented
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.8.18)
+    nfg_ui (0.9.9)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
+++ b/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
@@ -84,6 +84,7 @@ module NfgUi
             options.fetch(:remote, nil)
           end
 
+          # Render the component!
           def render_integrated_slat_action
             button ? render_button : render_link
           end
@@ -97,16 +98,6 @@ module NfgUi
           # The default `:secondary` theme can be manually overridden by passing in a
           # `:theme` trait or `:theme` option to the parent SlatActions component.
           def theme
-            # Note: this needs to be solved / addressed
-            # For whatever reason, the traits are not being picked up by the
-            # button version of the slat action.
-            # This ensures that any theme traits get applied here.
-            # calculated_theme = (traits & NfgUi::Components::Traits::Theme::COLOR_TRAITS)
-
-            # calculated_theme.any? ? calculated_theme.first : options[:theme]
-            # raise options.inspect
-            # options[:theme]
-            # options.fetch(:theme, super)
             options.fetch(:theme, nil)
           end
 
@@ -141,12 +132,7 @@ module NfgUi
           # and what is not allowed to pass into the
           # integrated component.
           def integrated_slat_action_button_component_options
-            # Do not set theme to nil (so theme defaults will run)
-            # Instead, do not pass in a theme at all.
-            # theme_options_hash = theme ? { theme: theme } : {}
-
             { theme: (theme || :secondary),
-              # **theme_options_hash,
               traits: traits,
               as: :a,
               confirm: confirm,
@@ -155,7 +141,7 @@ module NfgUi
               method: send(:method),
               remote: remote,
               outlined: outlined,
-              icon: icon }
+              left_icon: icon }
           end
 
           # Given the complexity of the data-attributes,

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.8.18'
+  VERSION = '0.9.9'
 end

--- a/spec/test_app/app/views/patterns/slats/index.html.haml
+++ b/spec/test_app/app/views/patterns/slats/index.html.haml
@@ -240,6 +240,7 @@
   ":warning trait (button)"
   %br
   = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: true
+  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: true, body: 'Delete'
 
   %p.my-3
   "Theme: :danger (button)"

--- a/spec/test_app/app/views/patterns/slats/index.html.haml
+++ b/spec/test_app/app/views/patterns/slats/index.html.haml
@@ -245,20 +245,24 @@
   "Theme: :danger (button)"
   %br
   = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo', button: true
+  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo', button: true, body: 'Delete'
   %p.my-3
   "No theme (button)"
   %br
   = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', button: true
-
+  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', button: true, body: 'Delete'
   %p.my-3
   ":warning trait (not button)"
   %br
   = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: false
+  = ui.nfg :slat_actions, :warning, menu: false, icon: 'trash', href: '#nogo', button: false, body: 'Delete'
   %p.my-3
   "theme: :danger (not button)"
   %br
   = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo'
+  = ui.nfg :slat_actions, theme: :danger, menu: false, icon: 'trash', href: '#nogo', body: 'Delete'
 
   %p.my-3
   "no theme"
   = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo'
+  = ui.nfg :slat_actions, menu: false, icon: 'trash', href: '#nogo', body: 'Delete'


### PR DESCRIPTION
@kylejmorin this is the hotfix you requested. Icons for the integrated slat actions sit on the left now when a button. We're using the `left_icon` option when we render the integrated slat action as a button.