### PR TITLE
Feature/step components to become span elements when not a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+# 0.9.12
+*Non-breaking changes*
+* `NfgUi::Components::Elements::StepIndicator` becomes an `<a>` tag when `:href` is present in `:options` and becomes a `<span>` when `:href` is not present.
+  * `StepIndicator` is now `Wrappable` and can have it's `:as` value changed in `:options`
+
 # 0.9.11
 *Non-breaking changes*
 * Adds an inky / Zurb Foundation for Emails `callout` component (which we label as 'alert').

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 *Non-breaking changes*
 * `NfgUi::Components::Elements::StepIndicator` becomes an `<a>` tag when `:href` is present in `:options` and becomes a `<span>` when `:href` is not present.
   * `StepIndicator` is now `Wrappable` and can have it's `:as` value changed in `:options`
+  * `StepIndicator` no longer renders an empty `Typeface` component when `:body` is empty in `:options`.
 
 # 0.9.11
 *Non-breaking changes*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.11)
+    nfg_ui (0.9.12)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/components/elements/step_indicator.rb
+++ b/lib/nfg_ui/components/elements/step_indicator.rb
@@ -19,12 +19,12 @@ module NfgUi
           content_tag(as, html_options) do
             concat(content_tag(:div, class: 'step-indicator') {
               if icon
-                NfgUi::Components::Foundations::Icon.new({ traits: [icon,] }, view_context).render
+                NfgUi::Components::Foundations::Icon.new({ traits: [icon] }, view_context).render
               else
                 step
               end
             })
-            concat(NfgUi::Components::Foundations::Typeface.new({ traits: [:muted], caption: (block_given? ? yield : body), class: 'mt-1 mb-0 step-text' }, view_context).render)
+            concat(NfgUi::Components::Foundations::Typeface.new({ traits: [:muted], caption: (block_given? ? yield : body), class: 'mt-1 mb-0 step-text' }, view_context).render) if (block_given? || body.present?)
           end
         end
 

--- a/lib/nfg_ui/components/elements/step_indicator.rb
+++ b/lib/nfg_ui/components/elements/step_indicator.rb
@@ -5,12 +5,10 @@ module NfgUi
     module Elements
       # Step doc coming soon
       class StepIndicator < NfgUi::Components::Elements::NavLink
+        include Bootstrap::Utilities::Wrappable
+
         def component_family
           :steps
-        end
-
-        def href
-          options.fetch(:href, '#')
         end
 
         def step
@@ -18,7 +16,7 @@ module NfgUi
         end
 
         def render
-          content_tag(:a, html_options) do
+          content_tag(as, html_options) do
             concat(content_tag(:div, class: 'step-indicator') {
               if icon
                 NfgUi::Components::Foundations::Icon.new({ traits: [icon,] }, view_context).render
@@ -31,6 +29,14 @@ module NfgUi
         end
 
         private
+
+        # Become a :span if :href is not present in options.
+        #
+        # While span is the defined default_html_wrapper_element in Bootstrap::Utilities::Wrappable,
+        # We set :span explicitly here because to ensure that regardless of what the default wrapper becomes, :span is preserved.
+        def default_html_wrapper_element
+          :span
+        end
 
         def non_html_attribute_options
           super.push(:step)

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.11'
+  VERSION = '0.9.12'
 end

--- a/spec/lib/nfg_ui/components/elements/step_indicator_spec.rb
+++ b/spec/lib/nfg_ui/components/elements/step_indicator_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.describe NfgUi::Components::Elements::StepIndicator do
+  let(:step_indicator) { described_class.new(options, ActionController::Base.new.view_context) }
+  let(:options) { {} }
+  it { expect(described_class).to be < NfgUi::Components::Elements::NavLink }
+  it_behaves_like 'a component with a consistent initalized construction'
+  it_behaves_like 'a component that includes the Wrappable utility module', component_suite: :nfg
+
+  describe '#component_family' do
+    subject { step_indicator.component_family }
+    it { is_expected.to eq :steps }
+  end
+
+  describe '#step' do
+    let(:options) { { step: tested_step } }
+    let(:tested_step) { nil }
+    subject { step_indicator.step }
+
+    context 'when :step is present in options' do
+      let(:tested_step) { 'tested step' }
+      it { is_expected.to eq tested_step }
+    end
+
+    context 'when :step is nil in options' do
+      let(:tested_step) { nil }
+      it { is_expected.to be_nil }
+    end
+
+    context 'when :step is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#render' do
+    subject { step_indicator.render }
+    it 'renders the base component without options' do
+      expect(subject).to eq "<span class=\"nav-link\"><div class=\"step-indicator\"></div></span>"
+    end
+
+    describe 'influencing the content_tag :as option for human accessibility' do
+      context 'rendering a step indicator as a link' do
+        let(:tested_href) { '#tested_href' }
+        let(:options) { { href: tested_href } }
+
+        it 'is a link with an href' do
+          expect(subject).to include "<a class=\"nav-link\" href=\"#{tested_href}\">"
+
+          and_it 'does not render the step indicator as a span' do
+            expect(subject).not_to include "<span class=\"nav-link\""
+          end
+        end
+      end
+
+      context 'rendering a step indicator as a span' do
+        it 'is not a link with an href' do
+          and_it 'renders the step indicator as a span without an href' do
+            expect(subject).to include "<span class=\"nav-link\">"
+          end
+
+          and_it 'does not render the step indicator as an anchor link' do
+            expect(subject).not_to include "<a class=\"nav-link\""
+          end
+        end
+      end
+    end
+
+    describe 'rendering the content in the .step-indicator' do
+      let(:options) { { icon: tested_icon, step: tested_step } }
+      let(:tested_step) { nil }
+      let(:tested_icon) { nil }
+
+      context 'when :icon is present in options' do
+        let(:tested_icon) { 'rocket' }
+
+        context 'and when :step is also present in options' do
+          let(:tested_step) { 'arbitrary' }
+
+          it 'ignores the :step option and renders the icon, instead in the indicator' do
+
+            expect(subject).to include "<span class=\"nav-link\"><div class=\"step-indicator\"><i aria-hidden=\"true\" class=\"fa fa-rocket\"></i></div>"
+
+            and_it 'does not include the step text' do
+              expect(subject).not_to include tested_step
+            end
+
+            and_it 'does include the icon' do
+              expect(subject).to include tested_icon
+            end
+          end
+        end
+
+        context 'and when :step is not present in options' do
+          let(:tested_step) { nil }
+          it 'renders the icon in the step indicator' do
+            expect(subject).to eq "<span class=\"nav-link\"><div class=\"step-indicator\"><i aria-hidden=\"true\" class=\"fa fa-rocket\"></i></div></span>"
+          end
+        end
+      end
+
+      context 'when :icon is not present in options' do
+        let(:tested_icon) { nil }
+
+        context 'when :step is present in options' do
+          let(:tested_step) { 'tested step' }
+          it 'renders the .step-indicator with the step' do
+            expect(subject).to include "<div class=\"step-indicator\">#{tested_step}</div>"
+          end
+        end
+
+        context 'when :step is not present in options' do
+          let(:tested_step) { nil }
+          it 'renders the .step-indicator with no content' do
+            expect(subject).to include "<div class=\"step-indicator\"></div>"
+          end
+        end
+      end
+    end
+
+    describe 'rendering a :body for the step indicator' do
+      let(:tested_body) { nil }
+      let(:options) { { body: tested_body } }
+
+      context 'when :body is present in options' do
+        let(:tested_body) { 'tested body' }
+        it 'renders the body within the caption typeface' do
+          expect(subject).to include "<p class=\"mt-1 mb-0 step-text text-muted font-size-sm\">#{tested_body}</p>"
+        end
+      end
+
+      context 'when :body is not present in options' do
+        let(:tested_body) { nil }
+        it 'does not render the caption typeface' do
+          expect(subject).not_to include "<p class=\"mt-1 mb-0 step-text text-muted font-size-sm\">"
+          expect(subject).to eq "<span class=\"nav-link\"><div class=\"step-indicator\"></div></span>"
+        end
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe '#default_html_wrapper_element' do
+      subject { step_indicator.send(:default_html_wrapper_element) }
+      it { is_expected.to eq :span }
+    end
+
+    describe '#non_html_attribute_options' do
+      subject { step_indicator.send(:non_html_attribute_options) }
+      it { is_expected.to include :step }
+    end
+  end
+end

--- a/spec/lib/nfg_ui/components/elements/step_spec.rb
+++ b/spec/lib/nfg_ui/components/elements/step_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe NfgUi::Components::Elements::Step do
     let(:options) { { step: tested_step, body: tested_body, icon: tested_icon, href: tested_href, disabled: tested_disabled } }
 
     it 'renders a basic default component when no options are set' do
-      expect(subject).to eq "<li class=\"nav-item disabled\" tabindex=\"-1\"><a class=\"nav-link disabled\" tabindex=\"-1\"><div class=\"step-indicator\"></div><p class=\"mt-1 mb-0 step-text text-muted\"></p></a></li>"
+      expect(subject).to eq "<li class=\"nav-item disabled\" tabindex=\"-1\"><span class=\"nav-link disabled\" tabindex=\"-1\"><div class=\"step-indicator\"></div></span></li>"
     end
 
     describe 'the :step option' do
@@ -167,7 +167,7 @@ RSpec.describe NfgUi::Components::Elements::Step do
     describe 'a disabled step' do
       let(:tested_disabled) { true }
       it 'renders the disabled step' do
-        expect(subject).to eq "<li class=\"nav-item disabled\" tabindex=\"-1\"><a class=\"nav-link disabled\" tabindex=\"-1\"><div class=\"step-indicator\"></div><p class=\"mt-1 mb-0 step-text text-muted\"></p></a></li>"
+        expect(subject).to eq "<li class=\"nav-item disabled\" tabindex=\"-1\"><span class=\"nav-link disabled\" tabindex=\"-1\"><div class=\"step-indicator\"></div></span></li>"
       end
     end
 
@@ -190,7 +190,7 @@ RSpec.describe NfgUi::Components::Elements::Step do
         let(:tested_active) { true }
         let(:tested_disabled) { false }
         it 'renders the step with a tooltip' do
-          expect(subject).to eq "<li class=\"nav-item active visited\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"tested tooltip\"><a class=\"nav-link\"><div class=\"step-indicator\"></div><p class=\"mt-1 mb-0 step-text text-muted\"></p></a></li>"
+          expect(subject).to eq "<li class=\"nav-item active visited\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"tested tooltip\"><span class=\"nav-link\"><div class=\"step-indicator\"></div></span></li>"
         end
       end
     end

--- a/spec/test_app/app/views/patterns/steps/index.html.haml
+++ b/spec/test_app/app/views/patterns/steps/index.html.haml
@@ -4,7 +4,7 @@
 %p Also note: active steps are both active & visited. Active is seen as a transitory step that augments a visited step's appearance.
 
 = ui.nfg :steps do
-  = ui.nfg :step, :visited, step: 1, body: 'Donation', href: '#back'
-  = ui.nfg :step, :active, step: 2, body: 'Your Info'
-  = ui.nfg :step, step: 3, body: 'Payment'
-  = ui.nfg :step, icon: 'check', body: 'Receipt'
+  = ui.nfg :step, :visited, step: 1, body: 'Donation (link)', href: '#back'
+  = ui.nfg :step, :active, step: 2, body: 'Your Info (span)'
+  = ui.nfg :step, step: 3, body: 'Payment (link)'
+  = ui.nfg :step, icon: 'check', body: 'Receipt (span)'

--- a/spec/test_app/app/views/patterns/steps/index.html.haml
+++ b/spec/test_app/app/views/patterns/steps/index.html.haml
@@ -8,3 +8,12 @@
   = ui.nfg :step, :active, step: 2, body: 'Your Info (span)'
   = ui.nfg :step, step: 3, body: 'Payment (link)'
   = ui.nfg :step, icon: 'check', body: 'Receipt (span)'
+
+%hr
+
+%h3 Steps without bodies
+= ui.nfg :steps do
+  = ui.nfg :step, :visited, step: 1, href: '#back'
+  = ui.nfg :step, :active, step: 2
+  = ui.nfg :step, step: 3, body: 'Verify verticality', href: '#test'
+  = ui.nfg :step, icon: 'check'


### PR DESCRIPTION
To improve human accessibility, the `StepIndicator`, which is what a `Step` renders automatically for us (akin to a bootstrap `NavItem` rendering a `NavLink`), now becomes a `:span` when `:href` is `nil` in the `:options` hash.

Additionally, the `Typeface` caption is removed when `:body` / the captured `block` is empty. This essentially removes empty paragraph tags from the interface when `:body` / `block` is empty... no empty `<p></p>`

Visible here:
http://localhost:3000/patterns/steps?stylesheet=public