### PR TITLE
Add the design system standard for tooltip icon usage. :tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.9.18
+* *Design System*: Adds `:tip` trait to the `NfgUi::Components::Foundations::Icon` which now auto-generates the design-system standard tootlip icon to be used whenever a tip/hint is provided on NFG apps. As of `0.9.18` the `:tip` trait is a `question-circle-o` icon.
+  * Example usage: `<%= ui.nfg :icon, :tip, tooltip: 'The tip!' %>`
+
 ## 0.9.17
 * Addresses security vulnerability with `Nokogiri` which must now be `1.10.4` or greater [CVE-2019-5477](https://nvd.nist.gov/vuln/detail/CVE-2019-5477)
 * `NfgUi::Bootstrap::Components::ButtonGroup`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.17)
+    nfg_ui (0.9.18)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/components/traits/icon.rb
+++ b/lib/nfg_ui/components/traits/icon.rb
@@ -5,10 +5,18 @@ module NfgUi
     module Traits
       # Access to pre-designed Icon traits
       module Icon
-        TRAITS = %i[loader].freeze
+        TRAITS = %i[loader tip].freeze
 
         def loader_trait
           options[:icon] = 'spinner spin fw'
+        end
+
+        # The defacto "(?)" tip icon
+        # Usage:
+        # ui.nfg :icon, :tip, tooltip: 'The tip'
+        def tip_trait
+          options[:icon] = 'question-circle-o'
+          options[:theme] = :info
         end
       end
     end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.17'
+  VERSION = '0.9.18'
 end

--- a/spec/lib/nfg_ui/components/traits/icon_spec.rb
+++ b/spec/lib/nfg_ui/components/traits/icon_spec.rb
@@ -1,13 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe NfgUi::Components::Traits::Icon do
-  let(:component_with_traits) { nil }
+  let(:component_with_traits) { FactoryBot.create(:icon, options: options) }
   let(:options) { {} }
-  let(:traits) { [] }
-
-  pending 'trait spec is needed'
 
   describe 'registered traits' do
     subject { described_class::TRAITS }
+    it { is_expected.to eq %i[loader tip] }
+  end
+
+  describe '#loader_trait' do
+    subject { component_with_traits.loader_trait }
+    it 'updates the icon to use a spinning spinner' do
+      by 'not updating the icon before the trait is applied' do
+        expect(component_with_traits.icon).not_to eq 'spinner spin fw'
+      end
+
+      and_by 'running the trait' do
+        subject # run the trait
+      end
+
+      and_it 'is the correct icon' do
+        expect(component_with_traits.icon).to eq 'spinner spin fw'
+      end
+    end
+  end
+
+  describe '#tip_trait' do
+    subject { component_with_traits.tip_trait }
+    it 'establishes the tip icon with correct options' do
+      by 'not being updated before running the trait' do
+        expect(component_with_traits.icon).not_to eq 'question-circle-o'
+        expect(component_with_traits.theme).not_to eq :info
+      end
+
+      and_by 'running the trait' do
+        subject # run the trait
+      end
+
+      and_it 'is the correct icon' do
+        expect(component_with_traits.icon).to eq 'question-circle-o'
+      end
+
+      and_it 'is the correct theme' do
+        expect(component_with_traits.theme).to eq :info
+      end
+    end
   end
 end

--- a/spec/test_app/app/views/foundations/icons/index.html.haml
+++ b/spec/test_app/app/views/foundations/icons/index.html.haml
@@ -6,7 +6,18 @@
 %hr
 
 %h2 Icons with custom traits
-= ui.nfg :icon, :loader
+%p
+  The loader icon:
+  %code :loader
+  %br
+  = ui.nfg :icon, :loader
+
+%p
+  The tip icon:
+  %code :tip
+  (remember to supply a tooltip!)
+  %br
+  = ui.nfg :icon, :tip, tooltip: 'The tip!'
 
 %h2 Icon with text, right & left
 = ui.nfg :icon, 'rocket', text: 'Icon on the left'


### PR DESCRIPTION
Creates an official :tip icon trait that'll become the standard for providing tooltip info hints throughout apps.

Usage: `ui.nfg :icon, :tip, tooltip: 'the tooltip'`