### PR TITLE
Feature/establish constant tip icon and theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.9.18.1
+* *Design System*: Establishes a centralized constant `DEFAULT_TIP_ICON` and `DEFAULT_TIP_THEME` for permeating tip styles and icons across other components. For example, `NfgUi::Components::Elements::Alert` has the `:tip` trait which applies the default tip icon and default tip theme to the alert.
+
 ## 0.9.18
 * *Design System*: Adds `:tip` trait to the `NfgUi::Components::Foundations::Icon` which now auto-generates the design-system standard tootlip icon to be used whenever a tip/hint is provided on NFG apps. As of `0.9.18` the `:tip` trait is a `question-circle-o` icon.
   * Example usage: `<%= ui.nfg :icon, :tip, tooltip: 'The tip!' %>`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.18)
+    nfg_ui (0.9.18.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui.rb
+++ b/lib/nfg_ui.rb
@@ -12,6 +12,9 @@ require 'inky'
 require 'momentjs-rails'
 
 module NfgUi
+  DEFAULT_TIP_ICON = 'question-circle-o'
+  DEFAULT_TIP_THEME = :info
+
   DEFAULT_BOOTSTRAP_THEME    = :primary
 
   BOOTSTRAP_THEMES           = %i[primary

--- a/lib/nfg_ui/components/traits/alert.rb
+++ b/lib/nfg_ui/components/traits/alert.rb
@@ -8,28 +8,10 @@ module NfgUi
         TRAITS = %i[tip].freeze
 
         def tip_trait
-          options[:icon] = 'lightbulb-o'
-          options[:theme] = :info
+          options[:icon] = NfgUi::DEFAULT_TIP_ICON
+          options[:theme] = NfgUi::DEFAULT_TIP_THEME
           options[:dismissible] = false
         end
-        # include NfgUi::Components::Traits
-        # include NfgUi::Components::Traits::Theme
-
-        # private
-
-        # def error_trait
-        #   @theme = :danger
-        #   @heading = 'Oops!'
-        #   @body = 'There was an error! Please review this submission and try again'
-        # end
-
-        # def allowed_traits
-        #   super.push(:dismissible, :error)
-        # end
-
-        # def skipped_traits
-        #   super.push(:dismissible)
-        # end
       end
     end
   end

--- a/lib/nfg_ui/components/traits/icon.rb
+++ b/lib/nfg_ui/components/traits/icon.rb
@@ -15,8 +15,8 @@ module NfgUi
         # Usage:
         # ui.nfg :icon, :tip, tooltip: 'The tip'
         def tip_trait
-          options[:icon] = 'question-circle-o'
-          options[:theme] = :info
+          options[:icon] = NfgUi::DEFAULT_TIP_ICON
+          options[:theme] = NfgUi::DEFAULT_TIP_THEME
         end
       end
     end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.18'
+  VERSION = '0.9.18.1'
 end

--- a/spec/lib/nfg_ui/components/traits/alert_spec.rb
+++ b/spec/lib/nfg_ui/components/traits/alert_spec.rb
@@ -1,13 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe NfgUi::Components::Traits::Alert do
-  let(:component_with_traits) { nil }
+  let(:component_with_traits) { FactoryBot.create(:alert, options: options) }
   let(:options) { {} }
-  let(:traits) { [] }
-
-  pending 'trait spec is needed'
 
   describe 'registered traits' do
     subject { described_class::TRAITS }
+    it { is_expected.to eq %i[tip] }
+  end
+
+  describe '#tip_trait' do
+    subject { component_with_traits.tip_trait }
+    it 'establishes the tip alert with correct options' do
+      by 'not being updated before running the trait' do
+        expect(component_with_traits.icon).not_to eq NfgUi::DEFAULT_TIP_ICON
+        expect(component_with_traits.theme).not_to eq NfgUi::DEFAULT_TIP_THEME
+      end
+
+      and_by 'running the trait' do
+        subject # run the trait
+      end
+
+      and_it 'applies the correct icon' do
+        expect(component_with_traits.icon).to eq NfgUi::DEFAULT_TIP_ICON
+      end
+
+      and_it 'applies the correct theme' do
+        expect(component_with_traits.theme).to eq NfgUi::DEFAULT_TIP_THEME
+      end
+
+      and_it 'is not a dismissible alert' do
+        expect(component_with_traits.dismissible).to eq false
+      end
+    end
   end
 end

--- a/spec/lib/nfg_ui/components/traits/icon_spec.rb
+++ b/spec/lib/nfg_ui/components/traits/icon_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe NfgUi::Components::Traits::Icon do
     subject { component_with_traits.tip_trait }
     it 'establishes the tip icon with correct options' do
       by 'not being updated before running the trait' do
-        expect(component_with_traits.icon).not_to eq 'question-circle-o'
-        expect(component_with_traits.theme).not_to eq :info
+        expect(component_with_traits.icon).not_to eq NfgUi::DEFAULT_TIP_ICON
+        expect(component_with_traits.theme).not_to eq NfgUi::DEFAULT_TIP_THEME
       end
 
       and_by 'running the trait' do
@@ -39,11 +39,11 @@ RSpec.describe NfgUi::Components::Traits::Icon do
       end
 
       and_it 'is the correct icon' do
-        expect(component_with_traits.icon).to eq 'question-circle-o'
+        expect(component_with_traits.icon).to eq NfgUi::DEFAULT_TIP_ICON
       end
 
       and_it 'is the correct theme' do
-        expect(component_with_traits.theme).to eq :info
+        expect(component_with_traits.theme).to eq NfgUi::DEFAULT_TIP_THEME
       end
     end
   end


### PR DESCRIPTION
This update touches `Alert` and `Icon` `:tip` traits. The goal was to create a centralized / constant definition of the tip icon and theme after noticing that our `:tip` traited alert used a different icon (a lightbulb) creating some inconsistency.

See `Alert` with `:tip` trait example:
http://localhost:3000/elements/alerts

See `Icon` with `:tip` trait example:
http://localhost:3000/foundations/icons

See [Changelog](https://github.com/network-for-good/nfg_ui/blob/feature/establish_constant_tip_icon_and_theme/CHANGELOG.md)