### PR TITLE
Provide responsive tables with ability to turn off captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 0.9.21
+* *NFG_UI:* Responsive tables can now have their scroll message optionally turned off by passing in `caption: nil` to the `:table`'s options.
+  * Example: `<%= ui.nfg :table, :responsive, caption: nil ...`
+  * You can add a custom caption by supply a caption in the `:options` hash, example: `caption: 'My custom caption'`
+  * Browse to `http://localhost:3000/elements/tables` to see them
+
+
 ## 0.9.20
 * Bootstrap and NFG modals are now sizable. See `https://getbootstrap.com/docs/4.3/components/modal/#optional-sizes`
   * Traits: add `:sm` `:lg` or `:xl` to nfg modals.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.20)
+    nfg_ui (0.9.21)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/components/elements/table.rb
+++ b/lib/nfg_ui/components/elements/table.rb
@@ -13,18 +13,33 @@ module NfgUi
         include NfgUi::Components::Traits::Size
         include NfgUi::Components::Traits::Table
 
+        def caption
+          options.fetch(:caption, default_caption)
+        end
+
         def render
           # We manually embed this caption as a typeface component
           # as part of the design pattern.
-          if responsive
+          if caption.present?
             capture do
-              concat(NfgUi::Components::Foundations::Typeface.new({caption: I18n.t('nfg_ui.components.elements.table.responsive_caption').to_s, class: 'mb-1 text-right', traits: [:muted]}, view_context).render)
+              concat(NfgUi::Components::Foundations::Typeface.new({caption: caption.to_s, class: 'mb-1 text-right', traits: [:muted]}, view_context).render)
 
               concat(super)
             end
           else
             super
           end
+        end
+
+        private
+
+        # By default, when responsive: supply a pre-written caption to the table
+        def default_caption
+          responsive ? I18n.t('nfg_ui.components.elements.table.responsive_caption') : ''
+        end
+
+        def non_html_attribute_options
+          super.push(:caption)
         end
       end
     end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.20'
+  VERSION = '0.9.21'
 end

--- a/spec/lib/nfg_ui/components/elements/table_spec.rb
+++ b/spec/lib/nfg_ui/components/elements/table_spec.rb
@@ -12,4 +12,61 @@ RSpec.describe NfgUi::Components::Elements::Table do
   it { expect(described_class.included_modules).to include NfgUi::Components::Utilities::Traitable }
   it { expect(described_class.included_modules).to include NfgUi::Components::Traits::Responsive }
   it { expect(described_class.included_modules).to include NfgUi::Components::Traits::Table }
+
+  describe '#caption' do
+    let(:tested_option) { :caption }
+    let(:default_caption) { 'fallback' }
+    before { allow(table).to receive(:default_caption).and_return(default_caption) }
+
+    subject { table.caption }
+
+    it_behaves_like 'a fetched option with a defined fallback', fallback: 'fallback'
+  end
+
+  describe '#render' do
+    subject { table.render }
+    describe 'table caption' do
+      let(:options) { { caption: tested_caption } }
+
+      context 'when :caption is present in options' do
+        let(:tested_caption) { 'tested caption' }
+        it 'supplies a caption' do
+          expect(subject).to include "<p class=\"mb-1 text-right text-muted font-size-sm\">#{tested_caption}</p>"
+        end
+      end
+
+      context 'when :caption is not present in options' do
+        let(:options) { {} }
+        it 'does not supply a caption' do
+          expect(subject).not_to include "<p class=\"mb-1 text-right text-muted font-size-sm\">"
+        end
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe '#default_caption' do
+      let(:options) { { responsive: tested_responsive } }
+      subject { table.send(:default_caption) }
+
+      context 'when :responsive is true in options' do
+        let(:tested_responsive) { true }
+        it 'returns the default responsive caption' do
+          expect(subject).to eq I18n.t('nfg_ui.components.elements.table.responsive_caption')
+        end
+      end
+
+      context 'when :responsive is falsey in options' do
+        let(:tested_responsive) { nil }
+        it 'does not supply a fallback' do
+          expect(subject).to be_blank
+        end
+      end
+    end
+
+    describe '#non_html_attribute_options' do
+      subject { table.send(:non_html_attribute_options) }
+      it { is_expected.to include :caption }
+    end
+  end
 end

--- a/spec/test_app/app/views/elements/tables/index.html.haml
+++ b/spec/test_app/app/views/elements/tables/index.html.haml
@@ -14,9 +14,20 @@
 %hr
 
 %h3 Responsive Tables
-/ = ui.nfg :typeface, :muted, caption: '<< Scroll left and right to see all data >>', class: 'mb-1 text-right'
-
 = ui.nfg :table, :responsive do
+  = render partial: 'elements/tables/table_body', locals: { lots_of_data: true }
+
+%hr
+%h4 Responsive Table with custom caption:
+%code.d-block.mb-4 caption: 'Custom caption'
+= ui.nfg :table, :responsive, caption: 'Custom caption' do
+  = render partial: 'elements/tables/table_body', locals: { lots_of_data: true }
+
+%hr
+
+%h4 Responsive Table with caption turned off:
+%code.d-block.mb-4 caption: nil || false
+= ui.nfg :table, :responsive, caption: nil do
   = render partial: 'elements/tables/table_body', locals: { lots_of_data: true }
 
 %hr


### PR DESCRIPTION
A need has come up to be able to remove the default responsive caption. To that end, this hotfix/feature looks to leverage the `caption` concept as a configurable sub component that also happens to be disableable via a falsey value in the options hash.

Example:
```haml
%h3 Responsive Tables
= ui.nfg :table, :responsive do
  = render partial: 'elements/tables/table_body', locals: { lots_of_data: true }

%hr
%h4 Responsive Table with custom caption:
%code.d-block.mb-4 caption: 'Custom caption'
= ui.nfg :table, :responsive, caption: 'Custom caption' do
  = render partial: 'elements/tables/table_body', locals: { lots_of_data: true }

%hr

%h4 Responsive Table with caption turned off:
%code.d-block.mb-4 caption: nil || false
= ui.nfg :table, :responsive, caption: nil do
  = render partial: 'elements/tables/table_body', locals: { lots_of_data: true }
```