### PR TITLE
Update modal to accept :class in options hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.9.24
+* `Modal` now accepts the `:class` option and will apply the class to the parent `.modal` element.
+
 ## 0.9.23
 * *NFG_UI* `:tip` `Icon`s have updated options.
   * `:tip` icons now have `right: true` by default when `:text` is present.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.23)
+    nfg_ui (0.9.24)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/bootstrap/components/modal.rb
+++ b/lib/nfg_ui/bootstrap/components/modal.rb
@@ -55,7 +55,7 @@ module NfgUi
 
         def css_classes
           [
-            component_css_class,
+            super,
             'fade'
           ].join(' ')
         end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.23'
+  VERSION = '0.9.24'
 end

--- a/spec/lib/nfg_ui/bootstrap/components/modal_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/modal_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe NfgUi::Bootstrap::Components::Modal do
   end
 
   describe '#css_classes' do
+    let(:options) { { class: 'test-class' } }
     subject { modal.send(:css_classes) }
-    it { is_expected.to eq 'modal fade' }
+    it { is_expected.to eq 'modal test-class fade' }
   end
 
   describe '#size' do


### PR DESCRIPTION
Seeks to update `Modal` to accept `:class` option that gets passed through via html_options. I think the original implementation was accidentally heavy-handed and the original intention was to implement the css_classes using the same pattern found everywhere else.

Solution: update `Modal#css_classes` to utilize `super` instead of the manually implemented approach.