### PR TITLE
Hotfix/resolve host engines not having access to vendors assets folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.9.24.1
+* Adds `vendors/assets/javascripts` to the `Engine`s `config.autoload_paths`. This resolves an issue where files in the `vendors` folder were not accessible to *host engines*.
+
 ## 0.9.24
 * `Modal` now accepts the `:class` option and will apply the class to the parent `.modal` element.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.24)
+    nfg_ui (0.9.24.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/engine.rb
+++ b/lib/nfg_ui/engine.rb
@@ -5,6 +5,7 @@ module NfgUi
     isolate_namespace NfgUi
 
     config.autoload_paths << Engine.root.join("lib")
+    config.autoload_paths << Engine.root.join("vendors", 'assets', 'javascripts')
 
     # Ensures that the config/nfg_ui_manifest.js file is compiled
     # which, in turn, ensures that all of the non-autoloaded assets

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.24'
+  VERSION = '0.9.24.1'
 end


### PR DESCRIPTION
Discovered recently that host engines (ex: nfg_csv_importer) were not adding nfg_ui's vendors/assets/javascripts folder to its lookup. Thus, it was unable to find bootstrap-datetimepicker on the host engine, despite host apps having access to it.

This hotfix updates this.