### PR TITLE
work out a way for traits to not overwrite supplied options in a component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## 0.9.25
+* Introduces the ability for traits to avoid overwriting pre-existing (manually set) component options. This is an optional implementation made available.
+* New trait utility added: `NfgUi::Components::Utilities::Traits::TraitUtilities`
+  * Provides a new method: `maybe_update_option(option_key, value:)`
+      * This method checks the component's :options hash for a pre-existing value (e.g.: `theme: :danger`) for that :options key
+      * If a value is detected for that :options key, it will not overwrite it.
+      * If no value is detected, it updates that options value
+* The following trait modules were updated:
+  * `NfgUi::Components::Traits::Alert`
+  * `NfgUi::Components::Traits::Icon`
+  * `NfgUi::Components::Traits::Navbar`
+
 ## 0.9.24.3
 * Removes `vendor/assets/javascripts` and moves the `bootstrap-datetimepicker.min.js` file into `app/assets/javascripts/nfg_ui/vendor/`
   * In effect, undoes `0.9.24.1`. After further testing, it did not reliably work for the host *engine*.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.24.3)
+    nfg_ui (0.9.25)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/components/traits/alert.rb
+++ b/lib/nfg_ui/components/traits/alert.rb
@@ -5,12 +5,14 @@ module NfgUi
     module Traits
       # Access to pre-designed Alert traits
       module Alert
+        include NfgUi::Components::Utilities::Traits::TraitUtilities
+
         TRAITS = %i[tip].freeze
 
         def tip_trait
-          options[:icon] = NfgUi::DEFAULT_TIP_ICON
-          options[:theme] = NfgUi::DEFAULT_TIP_THEME
-          options[:dismissible] = false
+          maybe_update_option(:icon, value: NfgUi::DEFAULT_TIP_ICON)
+          maybe_update_option(:theme, value: NfgUi::DEFAULT_TIP_THEME)
+          maybe_update_option(:dismissible, value: false)
         end
       end
     end

--- a/lib/nfg_ui/components/traits/alert.rb
+++ b/lib/nfg_ui/components/traits/alert.rb
@@ -5,8 +5,6 @@ module NfgUi
     module Traits
       # Access to pre-designed Alert traits
       module Alert
-        include NfgUi::Components::Utilities::Traits::TraitUtilities
-
         TRAITS = %i[tip].freeze
 
         def tip_trait

--- a/lib/nfg_ui/components/traits/alert.rb
+++ b/lib/nfg_ui/components/traits/alert.rb
@@ -5,6 +5,8 @@ module NfgUi
     module Traits
       # Access to pre-designed Alert traits
       module Alert
+        include NfgUi::Components::Utilities::Traits::TraitUtilities
+
         TRAITS = %i[tip].freeze
 
         def tip_trait

--- a/lib/nfg_ui/components/traits/icon.rb
+++ b/lib/nfg_ui/components/traits/icon.rb
@@ -5,6 +5,8 @@ module NfgUi
     module Traits
       # Access to pre-designed Icon traits
       module Icon
+        include NfgUi::Components::Utilities::Traits::TraitUtilities
+
         TRAITS = %i[loader tip].freeze
 
         def loader_trait
@@ -15,11 +17,12 @@ module NfgUi
         # Usage:
         # ui.nfg :icon, :tip, tooltip: 'The tip'
         def tip_trait
-          options[:icon] = NfgUi::DEFAULT_TIP_ICON
-          options[:theme] = NfgUi::DEFAULT_TIP_THEME
+          maybe_update_option(:icon, value: NfgUi::DEFAULT_TIP_ICON)
+
+          maybe_update_option(:theme, value: NfgUi::DEFAULT_TIP_THEME)
 
           if options[:text].present?
-            options[:right] = true
+            maybe_update_option(:right, value: true)
             options[:class] += ' fa-fw'
           end
         end

--- a/lib/nfg_ui/components/traits/navbar.rb
+++ b/lib/nfg_ui/components/traits/navbar.rb
@@ -5,12 +5,13 @@ module NfgUi
     module Traits
       # Access to pre-designed traits
       module Navbar
+        include NfgUi::Components::Utilities::Traits::TraitUtilities
+
         TRAITS = %i[white].freeze
 
         def white_trait
-          options[:light] = true
-          # options[:class] += ' bg-white'
-          options[:theme] = :white
+          maybe_update_option(:light, value: true)
+          maybe_update_option(:theme, value: :white)
         end
       end
     end

--- a/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
+++ b/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
@@ -5,7 +5,6 @@ module NfgUi
     module Utilities
       module Traits
         module TraitUtilities
-
           private
 
           # As a practice, traits are designed to help not rule.

--- a/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
+++ b/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
@@ -8,9 +8,10 @@ module NfgUi
 
           private
 
-          # As a practice, traits are designed to help not rule
+          # As a practice, traits are designed to help not rule.
+          #
           # Leveraging this method to conditionally overwrite values in the options hash
-          # ensures that users of the gem are able to leverage
+          # ensures that users of the gem are able to use
           # traits and further customize them on the fly.
           #
           # Example:
@@ -18,7 +19,7 @@ module NfgUi
           # Gem user wants to customize the theme in a unique setting
           # = ui.nfg :icon, :tip, theme: :danger
           #
-          # Without using this theme, theme: :danger would be ignored by by the :tip trait.
+          # Without using this #maybe_update_option method, `theme: :danger` would be ignored (and thus overwritten) by by the :tip trait
           #
           # When using this theme, the :tip trait would first check if theme is present _before_
           # setting the trait's theme value.

--- a/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
+++ b/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module NfgUi
+  module Components
+    module Utilities
+      module Traits
+        module TraitUtilities
+
+          private
+
+          # As a practice, traits are designed to help not rule
+          # Leveraging this method to conditionally overwrite values in the options hash
+          # ensures that users of the gem are able to leverage
+          # traits and further customize them on the fly.
+          #
+          # Example:
+          # An example trait adjusts an icon and the theme.
+          # Gem user wants to customize the theme in a unique setting
+          # = ui.nfg :icon, :tip, theme: :danger
+          #
+          # Without using this theme, theme: :danger would be ignored by by the :tip trait.
+          #
+          # When using this theme, the :tip trait would first check if theme is present _before_
+          # setting the trait's theme value.
+          def maybe_update_option(option_key, value:)
+            return if options[option_key].present?
+            options[option_key] = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
+++ b/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
@@ -19,7 +19,8 @@ module NfgUi
           # Gem user wants to customize the theme in a unique setting
           # = ui.nfg :icon, :tip, theme: :danger
           #
-          # Without using this #maybe_update_option method, `theme: :danger` would be ignored (and thus overwritten) by by the :tip trait
+          # Without using this #maybe_update_option method, `theme: :danger`
+          # would be ignored (and thus overwritten) by by the :tip trait
           #
           # When using this theme, the :tip trait would first check if theme is present _before_
           # setting the trait's theme value.

--- a/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
+++ b/lib/nfg_ui/components/utilities/traits/trait_utilities.rb
@@ -21,8 +21,28 @@ module NfgUi
           # Without using this #maybe_update_option method, `theme: :danger`
           # would be ignored (and thus overwritten) by by the :tip trait
           #
-          # When using this theme, the :tip trait would first check if theme is present _before_
-          # setting the trait's theme value.
+          # Thus, when using this method, the :tip trait would first check if :theme option is present _before_
+          # setting the established trait's options[:theme] value.
+          #
+          # It may not always be necessary or appropriate to use this method. For example,
+          # Some traits modify only one value in options, and if that trait is being overwritten by a supplied option,
+          # it defeats the purpose of the trait.
+          #
+          # Example where method usage is not necessary:
+          # def active_trait
+          #   options[:active] = true
+          # end
+          #
+          # Overall, trait creation doctrine really
+          # prefers usage of this method.
+          #
+          #
+          # Example Usage:
+          #
+          # def white_trait
+          #   maybe_update_option(:light, value: true)
+          #   maybe_update_option(:theme, value: :white)
+          # end
           def maybe_update_option(option_key, value:)
             return if options[option_key].present?
             options[option_key] = value

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.24.3'
+  VERSION = '0.9.25'
 end

--- a/spec/lib/nfg_ui/components/traits/icon_spec.rb
+++ b/spec/lib/nfg_ui/components/traits/icon_spec.rb
@@ -90,5 +90,45 @@ RSpec.describe NfgUi::Components::Traits::Icon do
         expect(component_with_traits.theme).to eq NfgUi::DEFAULT_TIP_THEME
       end
     end
+
+    context 'when options are preset in the options hash that compete with trait updates' do
+      let(:test_icon) { nil }
+      let(:test_theme) { nil }
+      let(:test_right) { nil }
+      let(:options) { { icon: test_icon, theme: test_theme, right: test_right } }
+
+      describe ':icon' do
+        let(:test_icon) { 'test-icon' }
+
+        it 'does not overwrite the supplied icon' do
+          subject
+          expect(component_with_traits.icon).not_to eq NfgUi::DEFAULT_TIP_ICON
+
+          expect(component_with_traits.icon).to eq test_icon
+        end
+      end
+
+      describe ':theme' do
+        let(:test_theme) { :danger }
+
+        it 'does not overwrite the supplied icon' do
+          subject
+          expect(component_with_traits.theme).not_to eq NfgUi::DEFAULT_TIP_THEME
+
+          expect(component_with_traits.theme).to eq test_theme
+        end
+      end
+
+      describe ':right' do
+        let(:test_right) { false }
+
+        it 'does not overwrite the supplied icon' do
+          subject
+          expect(component_with_traits.right).not_to eq true
+
+          expect(component_with_traits.right).to eq test_right
+        end
+      end
+    end
   end
 end

--- a/spec/test_app/app/views/foundations/icons/index.html.haml
+++ b/spec/test_app/app/views/foundations/icons/index.html.haml
@@ -17,7 +17,9 @@
   %code :tip
   (remember you can supply a tooltip!)
   %br
-  = ui.nfg :icon, :tip, tooltip: 'The tip!'
+  = ui.nfg :icon, :tip
+  = ui.nfg :icon, :tip, :danger, tooltip: 'The tip!'
+  = ui.nfg :icon, :tip, theme: :danger, tooltip: 'The tip!'
   %br
   The tip icon with text:
   %br


### PR DESCRIPTION
The original implementation expectations of a trait were that they are a tool that automates options and values on behalf of the gem user. Simplifying repetitive components (e.g. submit buttons, danger alerts, etc).

We discovered recently that traits are overwriting options, so while we would anticipate:
`= ui.nfg :icon, :tip, theme: :danger` to output a traited tip icon, it should also be danger themed.
However, traits will actually ignore the existing `options[:theme]` and overwrite it to the traits specifications.

Solution set is to implement a simple method that is used when needed (or where it makes sense) as a replacement for `options[:whatever] = 'trait_value'` and instead reads `maybe_update_option(:whatever, value: 'trait_value')`