### PR TITLE
Hotfix/pstwo 14285 convert reassign donor page to nfg ui  traited tip alert dismissible fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.9.25.1
+* `NfgUi::Components::Elements::Alert` `:tip` trait now sets `dismissable: false` correctly in the trait.
+
 ## 0.9.25
 * Introduces the ability for traits to avoid overwriting pre-existing (manually set) component options. This is an optional implementation made available.
 * New trait utility added: `NfgUi::Components::Utilities::Traits::TraitUtilities`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.9.25)
+    nfg_ui (0.9.25.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 1.1)

--- a/lib/nfg_ui/components/traits/alert.rb
+++ b/lib/nfg_ui/components/traits/alert.rb
@@ -12,7 +12,7 @@ module NfgUi
         def tip_trait
           maybe_update_option(:icon, value: NfgUi::DEFAULT_TIP_ICON)
           maybe_update_option(:theme, value: NfgUi::DEFAULT_TIP_THEME)
-          maybe_update_option(:dismissible, value: false)
+          options[:dismissible] = false
         end
       end
     end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.9.25'
+  VERSION = '0.9.25.1'
 end


### PR DESCRIPTION
The implementation of `maybe_update_option` in `0.9.25` did not account for the `dismissible` option being set by default on component initialization.

This update manually sets the `options[:dismissible]` value to `false` for the tip trait.

Working correctly screenshot from http://localhost:3000/elements/alerts

<img width="1560" alt="Screen Shot 2019-12-03 at 3 48 39 PM" src="https://user-images.githubusercontent.com/5702623/70088500-633eac80-15e4-11ea-81c5-89b2982e0b60.png">
