### PR TITLE
adds missing require browser to nfg_ui.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.10.1
+* Adds missing `require 'browser'` to nfg_ui.rb so that host apps have access to `browser` method on load.
+
 ## 0.10
 * *POTENTIAL BREAKING CHANGES*
 * Upgrades Browser gem to 2.7.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.10)
+    nfg_ui (0.10.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/lib/nfg_ui.rb
+++ b/lib/nfg_ui.rb
@@ -10,6 +10,7 @@ require 'sass-rails'
 require 'select2-rails'
 require 'inky'
 require 'momentjs-rails'
+require 'browser'
 
 module NfgUi
   DEFAULT_TIP_ICON = 'question-circle-o'

--- a/lib/nfg_ui/components/utilities/browser_detectable.rb
+++ b/lib/nfg_ui/components/utilities/browser_detectable.rb
@@ -5,8 +5,6 @@ module NfgUi
     module Utilities
       # Add browser detection to the desired component
       module BrowserDetectable
-        require 'browser'
-
         # Allow .mobile? .tablet?, etc to work
         # on browser.mobile?
         # to support legacy implementation and not require

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.10'
+  VERSION = '0.10.1'
 end


### PR DESCRIPTION
This was a hidden issue because one of our other engines had "require browser" in its main rb file. When I removed that, DMS suddenly stopped being able to find browser. 

This fixes that issue.