### PR TITLE
Update href method to use rails url_for helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 0.10.7
+* Updates `NfgUi::Bootstrap::Components::Base` `#href` method to leverage `view_context`'s `#url_for` so that ActiveRecord objects and hashes can be passed into the `href` option.
+  * Example: `= ui.nfg :button, href: @admin` now generates the path to the admin show page, e.g.: `admins/7`
+  * `= ui.nfg :button, href: { controller: 'admin', action: 'show', id: 7 }` will generate the same `admins/7` URL.
+* Updates `#href` method on `Button`, `PageItem`, `NavLink`, `NavbarBrand`, `PageItem`, `DropdownItem` and `IntegratedSlatAction` to leverage `super` instead of fetching `href` from options so that `url_for` is now in use when a fallback isn't set.
+
 ## 0.10.6
 * CSS Updates
   * Adds Donor Management container styles to support pre-NFG_UI styles

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.10.6)
+    nfg_ui (0.10.7)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)
@@ -106,7 +106,7 @@ GEM
       tilt
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    inky-rb (1.3.7.5)
+    inky-rb (1.3.8.0)
       foundation_emails (~> 2)
       nokogiri
     jquery-rails (4.3.5)

--- a/lib/nfg_ui/bootstrap/components/base.rb
+++ b/lib/nfg_ui/bootstrap/components/base.rb
@@ -76,7 +76,7 @@ module NfgUi
         def href
           options_href = options[:href]
 
-          return if options_href.nil? || options_href.empty?
+          return if options_href.blank?
           view_context.url_for(options_href)
         end
 

--- a/lib/nfg_ui/bootstrap/components/base.rb
+++ b/lib/nfg_ui/bootstrap/components/base.rb
@@ -65,7 +65,7 @@ module NfgUi
                                               # Example: <div class>Text</div>
         end
 
-        # Use view_context urL_for method to ensure that
+        # Use view_context url_for method to ensure that
         # when objects are passed into href, e.g.
         # `href: @admin` will convert it to the
         # correct path
@@ -74,8 +74,10 @@ module NfgUi
         # example:
         # href: { controller: 'admin', action: 'show', id: 7 }
         def href
-          return if options[:href].nil?
-          view_context.url_for(options[:href])
+          options_href = options[:href]
+
+          return if options_href.nil? || options_href.empty?
+          view_context.url_for(options_href)
         end
 
         def id

--- a/lib/nfg_ui/bootstrap/components/base.rb
+++ b/lib/nfg_ui/bootstrap/components/base.rb
@@ -67,8 +67,12 @@ module NfgUi
 
         # Use view_context urL_for method to ensure that
         # when objects are passed into href, e.g.
-        # `href: admin_path(admin)` will convert it to the
+        # `href: @admin` will convert it to the
         # correct path
+        #
+        # Likewise that hashes are also parsed correctly
+        # example:
+        # href: { controller: 'admin', action: 'show', id: 7 }
         def href
           return if options[:href].nil?
           view_context.url_for(options[:href])

--- a/lib/nfg_ui/bootstrap/components/base.rb
+++ b/lib/nfg_ui/bootstrap/components/base.rb
@@ -65,8 +65,13 @@ module NfgUi
                                               # Example: <div class>Text</div>
         end
 
+        # Use view_context urL_for method to ensure that
+        # when objects are passed into href, e.g.
+        # `href: admin_path(admin)` will convert it to the
+        # correct path
         def href
-          options[:href]
+          return if options[:href].nil?
+          view_context.url_for(options[:href])
         end
 
         def id

--- a/lib/nfg_ui/bootstrap/components/button.rb
+++ b/lib/nfg_ui/bootstrap/components/button.rb
@@ -36,7 +36,7 @@ module NfgUi
 
         def href
           return if as != :a
-          collapse ? collapse : (options[:href] || '#')
+          collapse ? collapse : (super || '#')
         end
 
         def remove_component_css_classes

--- a/lib/nfg_ui/bootstrap/components/button.rb
+++ b/lib/nfg_ui/bootstrap/components/button.rb
@@ -36,7 +36,7 @@ module NfgUi
 
         def href
           return if as != :a
-          collapse ? collapse : (super || '#')
+          collapse || super || '#'
         end
 
         def remove_component_css_classes

--- a/lib/nfg_ui/bootstrap/components/nav_link.rb
+++ b/lib/nfg_ui/bootstrap/components/nav_link.rb
@@ -18,10 +18,6 @@ module NfgUi
           options.fetch(:dropdown, false)
         end
 
-        def href
-          options.fetch(:href, nil)
-        end
-
         def tab
           options.fetch(:tab, nil)
         end

--- a/lib/nfg_ui/bootstrap/components/navbar_brand.rb
+++ b/lib/nfg_ui/bootstrap/components/navbar_brand.rb
@@ -11,7 +11,7 @@ module NfgUi
         end
 
         def href
-          options.fetch(:href, '#')
+          super || '#'
         end
 
         private

--- a/lib/nfg_ui/bootstrap/components/page_item.rb
+++ b/lib/nfg_ui/bootstrap/components/page_item.rb
@@ -18,7 +18,7 @@ module NfgUi
         end
 
         def href
-          super || '#' # return # when nil
+          super || '#'
         end
 
         # Send href through to the "page link" that's embedded within

--- a/lib/nfg_ui/bootstrap/components/page_item.rb
+++ b/lib/nfg_ui/bootstrap/components/page_item.rb
@@ -18,7 +18,7 @@ module NfgUi
         end
 
         def href
-          options[:href] || '#' # return # when nil
+          super || '#' # return # when nil
         end
 
         # Send href through to the "page link" that's embedded within

--- a/lib/nfg_ui/components/elements/dropdown_item.rb
+++ b/lib/nfg_ui/components/elements/dropdown_item.rb
@@ -47,7 +47,7 @@ module NfgUi
         # Automatically supply an :href to the dropdown item when a modal is present
         # so that the dropdown item presents correctly and appears clickable
         def href
-          modal ? options.fetch(:href, '#') : super
+          super || (modal ? '#' : nil)
         end
 
         private

--- a/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
+++ b/lib/nfg_ui/components/utilities/patches/integrated_slat_action.rb
@@ -62,7 +62,7 @@ module NfgUi
           # integrated action items are still
           # correctly styled
           def href
-            options[:href] || '#'
+            super || '#'
           end
 
           # Passes in the rails confirm option to the slat action component.

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.10.6'
+  VERSION = '0.10.7'
 end

--- a/spec/lib/nfg_ui/bootstrap/components/button_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/button_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe NfgUi::Bootstrap::Components::Button do
       let(:options) { {} }
       let(:tested_collapse) { '#tested_collapse' }
       let(:tested_modal) { '#tested_modal' }
+      let(:tested_href) { '#tested-href' }
 
       context 'href with collapse' do
         let(:options) { { collapse: tested_collapse } }
@@ -63,6 +64,23 @@ RSpec.describe NfgUi::Bootstrap::Components::Button do
         context 'when collapse is falsey' do
           let(:options) { { collapse: false } }
           it { is_expected.to eq '#' }
+        end
+
+        context 'when collapse is nil' do
+          let(:options) { { collapse: nil } }
+          it { is_expected.to eq '#' }
+        end
+
+        context 'when href is present' do
+
+          let(:options) { { collapse: nil, href: tested_href } }
+          it { is_expected.to eq tested_href }
+          it { is_expected.not_to eq '#' }
+        end
+
+        context 'when collapse and href are present' do
+          let(:options) { { href: tested_href, collapse: tested_collapse } }
+          it { is_expected.to eq tested_collapse }
         end
       end
     end

--- a/spec/lib/nfg_ui/bootstrap/components/navbar_brand_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/navbar_brand_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe NfgUi::Bootstrap::Components::NavbarBrand do
     end
 
     context 'when href is not present in options' do
+      let(:options) { {} }
       it { is_expected.to eq '#' }
     end
   end

--- a/spec/lib/nfg_ui/bootstrap/components/page_item_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/page_item_spec.rb
@@ -44,8 +44,18 @@ RSpec.describe NfgUi::Bootstrap::Components::PageItem do
       it { is_expected.to eq tested_href }
     end
 
-    context 'when href is not present in options' do
+    context 'when href is nil in options' do
       let(:options) { { href: nil } }
+      it { is_expected.to eq '#' }
+    end
+
+    context 'when href is not present in options' do
+      let(:options) { {} }
+      it { is_expected.to eq '#' }
+    end
+
+    context 'when href is an empty string in options' do
+      let(:options) { { href: '' } }
       it { is_expected.to eq '#' }
     end
   end

--- a/spec/test_app/app/views/elements/buttons/index.html.haml
+++ b/spec/test_app/app/views/elements/buttons/index.html.haml
@@ -42,7 +42,7 @@
 
 %h3 Buttons for Remote forms
 = ui.nfg :button, :submit, remote: true, describe: 'test remote', tooltip: 'Heavy button!', body: 'Remote button without trait'
-= ui.nfg :button, :submit, :disabled, remote: true, describe: 'test remote', tooltip: 'Heavy button!', body: 'Insanity in a button' 
+= ui.nfg :button, :submit, :disabled, remote: true, describe: 'test remote', tooltip: 'Heavy button!', body: 'Insanity in a button'
 = ui.nfg :button, :submit, :remote, body: 'Remote button with trait'
 
 %hr
@@ -56,7 +56,7 @@
 
 %h4 Icons on the left
 = ui.nfg :button, left_icon: 'rocket', body: 'Button with left icon (option)'
-= ui.nfg :button, left_icon: 'rocket' do 
+= ui.nfg :button, left_icon: 'rocket' do
   Button with left icon (block)
 = ui.nfg :button, :disabled, left_icon: 'rocket', body: 'Button with left icon disabled'
 = ui.nfg :button, :disabled, left_icon: 'rocket', body: 'Button with left icon disabled - tooltip', tooltip: 'Disabled button tooltip'
@@ -68,7 +68,7 @@
   Button with 2 Icons (block)
 = ui.nfg :button, :disabled, left_icon: 'plus', icon: 'rocket', body: 'Button with 2 Icons Disabled'
 = ui.nfg :button, :disabled, left_icon: 'plus', icon: 'rocket', body: 'Button with 2 Icons Disabled - tooltip', tooltip: 'Disabled button tooltip'
- 
+
 %hr
 
 %h4 Button with no body, but with icon
@@ -87,19 +87,19 @@
 
 = ui.nfg :button, as: :button, body: 'Primary', theme: :primary, class: 'example-class'
 
-= ui.nfg :button, as: :button, body: 'Secondary', theme: :secondary, class: 'example-class' 
+= ui.nfg :button, as: :button, body: 'Secondary', theme: :secondary, class: 'example-class'
 
-= ui.nfg :button, as: :button, body: 'Success', theme: :success, class: 'example-class' 
+= ui.nfg :button, as: :button, body: 'Success', theme: :success, class: 'example-class'
 
-= ui.nfg :button, as: :button, body: 'Danger', theme: :danger, class: 'example-class' 
+= ui.nfg :button, as: :button, body: 'Danger', theme: :danger, class: 'example-class'
 
-= ui.nfg :button, as: :button, body: 'Warning', theme: :warning, class: 'example-class' 
+= ui.nfg :button, as: :button, body: 'Warning', theme: :warning, class: 'example-class'
 
-= ui.nfg :button, as: :button, body: 'Info', theme: :info, class: 'example-class' 
+= ui.nfg :button, as: :button, body: 'Info', theme: :info, class: 'example-class'
 
-= ui.nfg :button, as: :button, body: 'Light', theme: :light, class: 'example-class' 
-= ui.nfg :button, as: :button, body: 'Dark', theme: :dark, class: 'example-class' 
-= ui.nfg :button, as: :button, body: 'Link', theme: :link, class: 'example-class' 
+= ui.nfg :button, as: :button, body: 'Light', theme: :light, class: 'example-class'
+= ui.nfg :button, as: :button, body: 'Dark', theme: :dark, class: 'example-class'
+= ui.nfg :button, as: :button, body: 'Link', theme: :link, class: 'example-class'
 
 %hr
 
@@ -141,18 +141,18 @@
 
 = ui.nfg :button, :outlined, as: :button, body: 'Primary Outlined', theme: :primary, class: 'example-class'
 
-= ui.nfg :button, :outlined, as: :button, body: 'Secondary Outlined', theme: :secondary, class: 'example-class' 
+= ui.nfg :button, :outlined, as: :button, body: 'Secondary Outlined', theme: :secondary, class: 'example-class'
 
-= ui.nfg :button, :outlined, as: :button, body: 'Success Outlined', theme: :success, class: 'example-class' 
+= ui.nfg :button, :outlined, as: :button, body: 'Success Outlined', theme: :success, class: 'example-class'
 
-= ui.nfg :button, :outlined, as: :button, body: 'Danger Outlined', theme: :danger, class: 'example-class' 
+= ui.nfg :button, :outlined, as: :button, body: 'Danger Outlined', theme: :danger, class: 'example-class'
 
-= ui.nfg :button, :outlined, as: :button, body: 'Warning Outlined', theme: :warning, class: 'example-class' 
+= ui.nfg :button, :outlined, as: :button, body: 'Warning Outlined', theme: :warning, class: 'example-class'
 
-= ui.nfg :button, :outlined, as: :button, body: 'Info Outlined', theme: :info, class: 'example-class' 
+= ui.nfg :button, :outlined, as: :button, body: 'Info Outlined', theme: :info, class: 'example-class'
 
-= ui.nfg :button, :outlined, as: :button, body: 'Light Outlined', theme: :light, class: 'example-class' 
-= ui.nfg :button, :outlined, as: :button, body: 'Dark Outlined', theme: :dark, class: 'example-class' 
+= ui.nfg :button, :outlined, as: :button, body: 'Light Outlined', theme: :light, class: 'example-class'
+= ui.nfg :button, :outlined, as: :button, body: 'Dark Outlined', theme: :dark, class: 'example-class'
 
 %hr
 
@@ -209,7 +209,7 @@
 
 %hr
 %h3 Additional rails-y buttons
-%p 
+%p
   method: :delete
   %br
   = ui.nfg :button, method: :delete, body: 'Method: :Delete button', describe: 'a description'


### PR DESCRIPTION
When creating a button that links to an AR object or a hash, we were running into issues with it outputting the AR object as a string.

`href: @admin` should go to `admins/7` but was not.

This update allows both strings (e.g.: 'http://www.google.com') and AR objects and hashes (`{controller: 'admin', action: 'show', id: 7}`) to work for passing into href.

Href triggers unique behavior across a few components so their associated component based href methods were also updated (for example, a button is converted to an :a element when href is present). 