### PR TITLE
adds responsive sizing helper classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,14 @@ jobs:
           - v1-dependencies-
 
       - run:
+          name: Force Bundler Version
+          command: |
+            sudo gem update --system
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler
+
+      - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
        - image: circleci/postgres:9.4
-          environment:
-            POSTGRES_HOST_AUTH_METHOD: trust
+         environment:
+           POSTGRES_HOST_AUTH_METHOD: trust
        - image: circleci/redis:4
 
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
        - image: circleci/postgres:9.4
+          environment:
+            POSTGRES_HOST_AUTH_METHOD: trust
        - image: circleci/redis:4
 
     working_directory: ~/repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.11.2.1
+* Adds responsive sizing helper classes (ex: `.w-md-50`)
+
 ## 0.11.2
 * Updates to Ruby 2.5.8 to match NFG app ruby versions while also necessary to support security vulnerability issues with Rails 5 and `ActionView`.
 * Addresses security vulnerability [GHSA-cfjv-5498-mph5](https://github.com/advisories/GHSA-cfjv-5498-mph5) by bumping `actionview` from `5.2.4.3` to `5.2.4.4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
-## 0.11.2.1
-* Adds responsive sizing helper classes (ex: `.w-md-50`)
+## 0.11.3
+* Adds responsive sizing helper classes to CSS (ex: `.w-md-50`)
 
 ## 0.11.2
 * Updates to Ruby 2.5.8 to match NFG app ruby versions while also necessary to support security vulnerability issues with Rails 5 and `ActionView`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.11.2)
+    nfg_ui (0.11.2.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)
@@ -278,4 +278,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.11.2.1)
+    nfg_ui (0.11.3)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_sizing.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_sizing.scss
@@ -1,0 +1,11 @@
+// Width and height based on viewport
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    @each $prop, $abbrev in (width: w, height: h) {
+      @each $size, $length in $sizes {
+        .#{$abbrev}#{$infix}-#{$size} { #{$prop}: $length !important; }
+      }
+    }
+  }
+}

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.11.2.1'
+  VERSION = '0.11.3'
 end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.11.2'
+  VERSION = '0.11.2.1'
 end


### PR DESCRIPTION
Introducing responsive sizing helper classes. Currently, bootstrap gives us `w-50` for `width: 50%;` but we can't control depending on the screen size. With this change, we'll be able to use helper classes like `w-md-50` where it will be on anything bigger than a medium screen. It uses the same syntax as the bootstrap spacing helper classes (ex: `mt-lg-3`).