### PR TITLE
Feature/dm 7614 convert admin details to nfg ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.11.5
+* Adds activity feed styles that are in DM, introduces icon-circle and skeleton styles. Skeleton comes with a loading sheen for future loading features.
+
 ## 0.11.4
 * `Modal` updates:
   * `:title` option is now optional. If left nil / empty, the `ModalHeader` component will not render. This is similar to `Tile`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.11.4)
+    nfg_ui (0.11.5)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_badge.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_badge.scss
@@ -1,9 +1,8 @@
 @each $color, $value in $colors {
   .#{$color} {
-    .badge-primary { @include badge-variant($value); }
+    .badge-primary {
+      @include badge-variant($value);
+      color: $white !important;
+    }
   }
 }
-
-// temporary color fix for consistency on a white text on orange bg
-// overrides color contrast settings
-.orange .badge-primary { color: $white !important; }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_buttons.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_buttons.scss
@@ -1,6 +1,9 @@
 @each $color, $value in $colors {
   .#{$color} {
-    .btn-primary { @include button-variant($value, $value); }
+    .btn-primary {
+      @include button-variant($value, $value);
+      color: $white !important;
+    }
     .show > .btn-primary.dropdown-toggle {
       background-color: darken($value, 10%);
       border-color: darken($value, 10%);
@@ -8,7 +11,3 @@
     .btn-outline-secondary, .btn-link { color: $value; }
   }
 }
-
-// temporary color fix for consistency on a white text on orange bg
-// overrides color contrast settings
-.orange .btn-primary { color: $white !important; }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_custom.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_custom.scss
@@ -1,3 +1,4 @@
 // Our custom styles
+@import 'custom/activity_feed';
 @import 'custom/icons';
 @import 'custom/nav_step';

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_reboot.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_reboot.scss
@@ -1,6 +1,6 @@
 @each $color, $value in $colors {
   .#{$color} {
-    a:not(.btn) {
+    a:not(.dropdown-item) {
       color: $value;
       @include hover { color: darken($value, 15%); }
     }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/custom/_activity_feed.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/custom/_activity_feed.scss
@@ -1,0 +1,7 @@
+@each $color, $value in $colors {
+  .activity-feed-item {
+    &.#{nth($color, 1)} {
+      .activity-icon { background-color: $value; }
+    }
+  }
+}

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom.scss
@@ -1,4 +1,5 @@
 // Our custom styles
+@import 'custom/activity_feed';
 @import 'custom/builder_layout';
 @import 'custom/campaign_card';
 @import 'custom/campaign_preview';

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_activity_feed.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_activity_feed.scss
@@ -1,0 +1,34 @@
+// Activity feed list items
+.activity-feed-item {
+  position: relative;
+  padding: 0 0 $spacer ($spacer * 1.5);
+  border: none;
+  z-index: 0;
+  &::after {
+    position: absolute;
+    top: 0;
+    left: 12px;
+    bottom: 0;
+    z-index: 0;
+    border-left: $border-width solid $border-color;
+    content: "";
+  }
+  &:last-child {
+    padding-bottom: 0;
+    &::after { display: none; }
+  }
+  .activity-icon {
+    position: absolute;
+    top: 2px;
+    left: 0;
+    display: block;
+    width: $spacer;
+    height: $spacer;
+    font-size: $font-size-sm;
+    line-height: $spacer;
+    z-index: 1;
+    text-align: center;
+    @include border-radius(50%);
+    box-shadow: 0 0 0 2px rgba(255,255,255,1);
+  }
+}

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_overlay_blocker.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_overlay_blocker.scss
@@ -40,7 +40,7 @@ $redacted-font-family: "BLOKK";
   font-family: $font-family-base;
   letter-spacing: 0;
   word-spacing: 0;
-  background-color: rgba(255,255,255,0.9);
+  background-color: transparentize($white, 0.2);
 }
 .overlay-blur {
   transition: $transition-base;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/legacy_browser_support/nfg_theme/_custom.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/legacy_browser_support/nfg_theme/_custom.scss
@@ -1,6 +1,7 @@
 // Our custom styles
 @import 'custom/avatar';
 @import 'custom/everyday_giving';
+@import 'custom/icon';
 @import 'custom/nav_step';
 @import 'custom/slat';
 @import 'custom/video_countdown';

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/legacy_browser_support/nfg_theme/custom/_icon.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/legacy_browser_support/nfg_theme/custom/_icon.scss
@@ -1,0 +1,5 @@
+.icon-circle {
+  display: -ms-inline-flexbox;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
+}

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_custom-forms.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_custom-forms.scss
@@ -10,6 +10,7 @@
     }
     &:focus:not(:checked) ~ .custom-control-label::before { border-color: $input-border-color; }
   }
+  + .custom-control:not(.custom-control-inline) { margin-top: ($spacer * .25); }
 }
 
 // Custom control indicators
@@ -41,6 +42,9 @@
 //
 
 .custom-select {
+  display: block;
+  width: auto;
+  max-width: 100%;
   font-weight: $btn-font-weight;
   cursor: pointer;
   box-shadow: none;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_custom.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_custom.scss
@@ -1,11 +1,13 @@
 // Our custom styles
 @import 'custom/avatar';
 @import 'custom/device_preview';
+@import 'custom/icon';
 @import 'custom/illustration';
 @import 'custom/mobile';
 @import 'custom/nav_step';
 @import 'custom/redactor';
 @import 'custom/social_share';
+@import 'custom/skeleton';
 @import 'custom/slat';
 @import 'custom/ticket';
 @import 'custom/tile';

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_dropdown.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_dropdown.scss
@@ -3,7 +3,6 @@
 
 // Links, buttons, and more within the dropdown menu
 .dropdown-item {
-  color: inherit !important; // overrides color_variations <a> styles
   + .dropdown-item { border-top: $border-width solid $border-color; }
   &.disabled, &:disabled {
     background-color: $body-bg;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_dropdown.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_dropdown.scss
@@ -3,6 +3,7 @@
 
 // Links, buttons, and more within the dropdown menu
 .dropdown-item {
+  color: inherit !important; // overrides color_variations <a> styles
   + .dropdown-item { border-top: $border-width solid $border-color; }
   &.disabled, &:disabled {
     background-color: $body-bg;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_avatar.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_avatar.scss
@@ -21,7 +21,7 @@
   .avatar-text {
     font-weight: $font-weight-bold;
     font-size: $font-size-base;
-    line-height: 1;
+    line-height: 1.2;
     color: $body-color;
     text-align: center;
     white-space: nowrap;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_icon.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_icon.scss
@@ -1,0 +1,34 @@
+// Custom icon styles
+// icons shouldn't be larger than the h1 font-size. use illustrations for larger visuals.
+// don't use icon circles for icons smaller than icon-circle-sm size. use just an icon.
+.icon-circle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  width: ($spacer * 1.5);
+  height: ($spacer * 1.5);
+  font-size: $font-size-base;
+  background-color: $border-color;
+  border-radius: 50%;
+  &.icon-circle-outline {
+    background-color: $white;
+    border: $border-width solid $border-color;
+  }
+  &.icon-circle-sm {
+    width: $spacer;
+    height: $spacer;
+    font-size: $font-size-sm;
+  }
+  &.icon-circle-lg {
+    width: ($spacer * 2);
+    height: ($spacer * 2);
+    font-size: $font-size-lg;
+  }
+  &.icon-circle-xl {
+    width: ($spacer * 3);
+    height: ($spacer * 3);
+    font-size: $h1-font-size;
+  }
+}

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_skeleton.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_skeleton.scss
@@ -1,0 +1,50 @@
+// Skeleton styles for placheholder content
+.skeleton-avatar, .skeleton-heading, .skeleton-paragraph {
+  display: inline-block;
+  margin-bottom: ($spacer * .5);
+  background-color: $border-color;
+  overflow: hidden;
+  &::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: $body-bg;
+    animation: skeleton-sheen 1s linear infinite alternate;
+    content: '';
+
+    // any skeleton element inside a container with the the .loaded class removes the sheen animation.
+    .loaded & {
+      background-color: transparent;
+      animation: none;
+    }
+  }
+}
+.skeleton-avatar {
+  width: ($spacer * 1.5);
+  height: ($spacer * 1.5);
+  border-radius: 50%;
+}
+.skeleton-heading {
+  width: 70%;
+  height: $spacer;
+  border-radius: ($spacer * .5);
+  &:nth-child(even) { width: 45%; }
+}
+.skeleton-paragraph {
+  width: 100%;
+  height: ($spacer * .5);
+  border-radius: ($spacer * .25);
+  &:nth-child(2n+1) { width: 90%; }
+  &:nth-child(3n+1) { width: 75%; }
+  &:nth-child(4n+1) { width: 80%; }
+}
+
+// Sheen animation used on skeleton elements
+@keyframes skeleton-sheen {
+  0% { opacity: .45; }
+  to { opacity: .9; }
+}

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_tile.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/custom/_tile.scss
@@ -22,13 +22,13 @@
   display: block;
   margin-right: auto;
   margin-left: auto;
-  @include media-breakpoint-down(sm) { padding-bottom: $grid-gutter-width; }
-  @include media-breakpoint-up(sm) { padding-bottom: ($grid-gutter-width * 1.5); }
+  @include media-breakpoint-down(sm) { padding-bottom: ($grid-gutter-width * 1.5); }
+  @include media-breakpoint-up(sm) { padding-bottom: ($grid-gutter-width * 2); }
   &:last-child { padding-bottom: 0; }
   + .tile-section {
     border-top: $border-width solid $border-color;
-    @include media-breakpoint-down(sm) { padding-top: $grid-gutter-width; }
-    @include media-breakpoint-up(sm) { padding-top: ($grid-gutter-width * 1.5); }
+    @include media-breakpoint-down(sm) { padding-top: ($grid-gutter-width * 1.5); }
+    @include media-breakpoint-up(sm) { padding-top: ($grid-gutter-width * 2); }
   }
 }
 

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.11.4'
+  VERSION = '0.11.5'
 end


### PR DESCRIPTION
Adds activity feed styles that are in DM, introduces icon-circle and skeleton styles.

Skeleton (comes with a loading sheen for future loading features):
![Screen Shot 2020-10-29 at 2 58 40 PM](https://user-images.githubusercontent.com/16546623/97619980-49c20280-19f7-11eb-8716-c2d124b055c3.png)

Icon-circle (multiple sizes and a little more flexibility than a stacked fontawesome icon):
![Screen Shot 2020-10-29 at 2 58 44 PM](https://user-images.githubusercontent.com/16546623/97620010-55152e00-19f7-11eb-8094-da2e6539367a.png)

