### PR TITLE
feature/DM-7727_email_gallery_draft_composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.11.8
+* CSS style additions for beefree.io editor
+  * Added support for Beefree.io editor to render with a height when it is in and out of the builder layout. There's support for when there is and is not the builder-nav (typically used for step navigation in an onboarder).
+* Removes listed rogue `muted` trait from `Typeface` traits on `lib/nfg_ui/components/traits/typeface.rb`.
+
 ## 0.11.7
 * CSS style updates for custom form elements.
   * There was a gap between the checkbox/radio/switch that didn't allow the user to select the option -- resulting in a poor UX where the user would have to click either the icon or the language for it to work.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.11.7)
+    nfg_ui (0.11.8)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom.scss
@@ -1,5 +1,6 @@
 // Our custom styles
 @import 'custom/activity_feed';
+@import 'custom/bee';
 @import 'custom/builder_layout';
 @import 'custom/campaign_card';
 @import 'custom/campaign_preview';

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_bee.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_bee.scss
@@ -1,0 +1,15 @@
+#bee_plugin_container {
+  height: 600px; // fallback value if calc() isn't supported
+  border-top: 1px solid $border-color;
+  border-bottom: 1px solid $border-color;
+}
+
+// Height if just the builder-header is present
+.builder-header + .builder-container {
+  #bee_plugin_container { height: calc(100vh - 72px); }
+}
+
+// Height if both builder-header and builder-nav are present (typical in onboarder)
+.builder-header + .builder-nav + .builder-container {
+  #bee_plugin_container { height: calc(100vh - 180px); }
+}

--- a/lib/nfg_ui/components/traits/typeface.rb
+++ b/lib/nfg_ui/components/traits/typeface.rb
@@ -10,7 +10,6 @@ module NfgUi
                     heading
                     subheading
                     title
-                    muted
                     truncate].freeze
 
         def body_trait

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.11.7'
+  VERSION = '0.11.8'
 end

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (0.11.7)
+    nfg_ui (0.11.8)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)


### PR DESCRIPTION
No builder-nav example:
![Screen Shot 2020-12-08 at 3 22 58 PM](https://user-images.githubusercontent.com/16546623/101537478-86273d80-3969-11eb-94f5-0643791a80c8.png)

With builder-nav example:
![Screen Shot 2020-12-08 at 3 22 40 PM](https://user-images.githubusercontent.com/16546623/101537469-83c4e380-3969-11eb-9bfc-da0d56d7e997.png)
