### PR TITLE
Adds tooltips to slat item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.11.9
+* `SlatItem` is now `Tooltipable` and can have tooltips passed in via its options: `ui.nfg(:slat_item, slat_header: 'Test', tooltip: 'The Tooltip')`
+
 ## 0.11.8
 * CSS style additions for beefree.io editor
   * Added support for Beefree.io editor to render with a height when it is in and out of the builder layout. There's support for when there is and is not the builder-nav (typically used for step navigation in an onboarder).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.11.8)
+    nfg_ui (0.11.9)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/lib/nfg_ui/components/elements/slat_item.rb
+++ b/lib/nfg_ui/components/elements/slat_item.rb
@@ -66,7 +66,7 @@ module NfgUi
 
         # Strip the href from html_options and pass it to the header
         def slat_item_html_options
-          options = html_options.except(:href, :tooltip)
+          options = html_options.except(:href)
 
           # merge in tooltip only if leveraging block body content
           options.merge!(tooltip_html_options) unless (heading || caption || slat_header)

--- a/lib/nfg_ui/components/elements/slat_item.rb
+++ b/lib/nfg_ui/components/elements/slat_item.rb
@@ -11,6 +11,10 @@ module NfgUi
         include NfgUi::Components::Traits::Size
         include NfgUi::Components::Traits::SlatItem
 
+        def caption
+          options.fetch(:caption, nil)
+        end
+
         def component_family
           :slats
         end
@@ -19,36 +23,55 @@ module NfgUi
           options.fetch(:slat_header, nil)
         end
 
-        def caption
-          options.fetch(:caption, nil)
+        # Leverage custom tooltip implementation
+        # so that tooltips are connected to slat item text
+        # and not the slat item containing div (resulting in better UI)
+        def tooltip
+          options.fetch(:tooltip, nil)
         end
 
         def render
           content_tag(base_element, slat_item_html_options) do
             if slat_header
-              concat(content_tag(:h6, slat_header, class: 'display-4 slat-column-header'))
+              concat(content_tag(:h6, slat_header, class: 'display-4 slat-column-header', **tooltip_html_options))
             end
             if heading
               if href
                 concat(content_tag(:a, href: view_context.url_for(href)) {
-                  NfgUi::Components::Foundations::Typeface.new({ subheading: heading }, view_context).render
+                  NfgUi::Components::Foundations::Typeface.new({ subheading: heading, tooltip: tooltip }, view_context).render
                 })
               else
-                concat(NfgUi::Components::Foundations::Typeface.new({ subheading: heading }, view_context).render)
+                concat(NfgUi::Components::Foundations::Typeface.new({ subheading: heading, tooltip: tooltip }, view_context).render)
               end
             end
             concat(block_given? ? yield : body)
             if caption
-              concat(NfgUi::Components::Foundations::Typeface.new({ caption: caption, class: 'mb-0' }, view_context).render)
+              concat(NfgUi::Components::Foundations::Typeface.new({ caption: caption, class: 'mb-0', tooltip: (tooltip unless heading) }, view_context).render)
             end
           end
         end
 
         private
 
+        def tooltip_html_options
+          return {} unless tooltip
+          { title: tooltip, data: options[:data].merge(tooltip_data_attributes) }
+        end
+
+        def tooltip_data_attributes
+          { toggle: 'tooltip',
+            placement: :top,
+            html: 'true' }
+        end
+
         # Strip the href from html_options and pass it to the header
         def slat_item_html_options
-          html_options.except(:href)
+          options = html_options.except(:href, :tooltip)
+
+          # merge in tooltip only if leveraging block body content
+          options.merge!(tooltip_html_options) unless (heading || caption || slat_header)
+
+          options
         end
 
         # :sm is the default size, and is not given
@@ -59,7 +82,7 @@ module NfgUi
         end
 
         def non_html_attribute_options
-          super.push(:slat_header, :caption)
+          super.push(:slat_header, :caption, :tooltip)
         end
       end
     end

--- a/lib/nfg_ui/components/elements/slat_item.rb
+++ b/lib/nfg_ui/components/elements/slat_item.rb
@@ -69,6 +69,7 @@ module NfgUi
           options = html_options.except(:href)
 
           # merge in tooltip only if leveraging block body content
+          # tooltip_html_options will return {} if no tooltip so this is a safe merge
           options.merge!(tooltip_html_options) unless (heading || caption || slat_header)
 
           options

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.11.8'
+  VERSION = '0.11.9'
 end

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (0.11.8)
+    nfg_ui (0.11.9)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/spec/features/nfg_ui/tooltip_interactions_spec.rb
+++ b/spec/features/nfg_ui/tooltip_interactions_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Activating a tooltip on all tooltippable components', type: :fea
       pending "[data-describe='disabled-nav-item-wrapper'] [data-toggle='tooltip'] does not yet work"
     end
 
-    describe 'tooltips on slact actions' do
+    describe 'tooltips on slat actions' do
       let(:tooltippable_component_selectors) { ["[data-describe='tooltip-slat-action']","[data-describe='tooltip-slat-action-with-href']","[data-describe='modal-slat-action-with-tooltip']","[data-describe='disabled-slat-action-wrapper'] [data-toggle='tooltip']" ] }
 
       it 'activates tooltips on tooltippable slat action items' do
@@ -90,6 +90,13 @@ RSpec.describe 'Activating a tooltip on all tooltippable components', type: :fea
           page.find("body").click
         end
       end
+    end
+
+    describe 'tooltips on slat items' do
+      let(:tooltippable_component_selectors) {
+        ["[data-describe='tooltip-slat-header'] .slat-column-header", "[data-describe='tooltip-slat-heading'] a h6", "[data-describe='tooltip-full-slat-item'] h6", "[data-describe='tooltip-body-slat-item']", "[data-describe='tooltip-caption-slat-item'] p.font-size-sm"]
+      }
+      it_behaves_like 'tooltippable components that activate a tooltip'
     end
 
     describe 'tooltips on steps' do
@@ -130,10 +137,12 @@ end
 private
 
 def wait_for_tooltip
-  sleep 0.5
+  sleep 1
 end
 
 def confirm_tooltip_presence(selector:)
+  scroll_to_element selector
+  sleep 0.1
   page.find(selector).hover
   wait_for_tooltip
   expect(page).to have_css tooltip_id(selector: selector)

--- a/spec/features/nfg_ui/tooltip_interactions_spec.rb
+++ b/spec/features/nfg_ui/tooltip_interactions_spec.rb
@@ -94,7 +94,13 @@ RSpec.describe 'Activating a tooltip on all tooltippable components', type: :fea
 
     describe 'tooltips on slat items' do
       let(:tooltippable_component_selectors) {
-        ["[data-describe='tooltip-slat-header'] .slat-column-header", "[data-describe='tooltip-slat-heading'] a h6", "[data-describe='tooltip-full-slat-item'] h6", "[data-describe='tooltip-body-slat-item']", "[data-describe='tooltip-caption-slat-item'] p.font-size-sm"]
+        [
+          "[data-describe='tooltip-slat-header'] .slat-column-header",
+          "[data-describe='tooltip-slat-heading'] a h6",
+          "[data-describe='tooltip-full-slat-item'] h6",
+          "[data-describe='tooltip-body-slat-item']",
+          "[data-describe='tooltip-caption-slat-item'] p.font-size-sm"
+        ]
       }
       it_behaves_like 'tooltippable components that activate a tooltip'
     end

--- a/spec/lib/nfg_ui/components/elements/slat_item_spec.rb
+++ b/spec/lib/nfg_ui/components/elements/slat_item_spec.rb
@@ -33,13 +33,33 @@ RSpec.describe NfgUi::Components::Elements::SlatItem do
     end
 
     describe 'slat_header' do
-      let(:options) { { slat_header: tested_slat_header } }
+      let(:options) { { slat_header: tested_slat_header, tooltip: tested_tooltip } }
+      let(:tested_tooltip) { nil }
+
       context 'when slat_header is present' do
         let(:tested_slat_header) { 'Tested slat header' }
         it 'includes the slat header' do
           expect(rendered_html).to eq "<div class=\"slat-item\"><h6 class=\"display-4 slat-column-header\">#{tested_slat_header}</h6></div>"
 
           expect(subject).to have_css '.slat-item h6.display-4.slat-column-header'
+        end
+
+        describe 'tooltip presence in options' do
+          context 'when tooltip is present' do
+            let(:tested_tooltip) { 'tooltip' }
+            it 'includes the tooltip on the slat column header' do
+              expect(rendered_html).to eq "<div class=\"slat-item\"><h6 class=\"display-4 slat-column-header\" title=\"#{tested_tooltip}\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\">#{tested_slat_header}</h6></div>"
+              expect(subject).to have_css "[data-toggle='tooltip']"
+
+            end
+          end
+
+          context 'when tooltip is not present' do
+            let(:tested_tooltip) { nil }
+            it 'does not include tooltip markup in the HTML' do
+              expect(subject).not_to have_css "[data-toggle='tooltip']"
+            end
+          end
         end
       end
 
@@ -52,9 +72,10 @@ RSpec.describe NfgUi::Components::Elements::SlatItem do
     end
 
     describe 'heading' do
-      let(:options) { { heading: tested_heading, href: tested_href } }
+      let(:options) { { heading: tested_heading, href: tested_href, tooltip: tested_tooltip } }
       let(:tested_heading) { nil }
       let(:tested_href) { nil }
+      let(:tested_tooltip) { nil }
 
       context 'when heading is present' do
         let(:tested_heading) { 'Tested heading' }
@@ -74,6 +95,25 @@ RSpec.describe NfgUi::Components::Elements::SlatItem do
             expect(subject).to have_css '.slat-item h6'
           end
         end
+
+        describe 'tooltip on the heading' do
+          context 'when tooltip is present' do
+            let(:tested_tooltip) { 'tested tooltip' }
+            it 'applies the tooltip on the heading only' do
+              expect(rendered_html).to eq "<div class=\"slat-item\"><h6 data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"#{tested_tooltip}\">#{tested_heading}</h6></div>"
+
+              expect(subject).to have_css "h6[data-toggle='tooltip']"
+            end
+          end
+
+          context 'when tooltip is not present' do
+            let(:tested_tooltip) { nil }
+
+            it 'does not add tooltip markup to the heading' do
+              expect(subject).not_to have_css "h6[data-toggle='tooltip']"
+            end
+          end
+        end
       end
 
       context 'when heading is not present' do
@@ -84,16 +124,35 @@ RSpec.describe NfgUi::Components::Elements::SlatItem do
     end
 
     describe 'rendering the body' do
-      let(:options) { { body: tested_body } }
+      let(:options) { { body: tested_body, tooltip: tested_tooltip } }
       let(:tested_body) { 'tested body' }
+      let(:tested_tooltip) { nil }
 
       it 'renders the body' do
         expect(rendered_html).to eq "<div class=\"slat-item\">#{tested_body}</div>"
       end
+
+      describe 'tooltip presence on body' do
+        context 'when a tooltip is present' do
+          let(:tested_tooltip) { 'tested tooltip' }
+          it 'adds a tooltip to the slat item' do
+            expect(rendered_html).to eq "<div class=\"slat-item\" title=\"#{tested_tooltip}\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\">#{tested_body}</div>"
+            expect(subject).to have_css ".slat-item[data-toggle='tooltip']"
+          end
+        end
+
+        context 'when a tooltip is not present' do
+          let(:tested_tooltip) { nil }
+          it 'does not add a tooltip markup html to the slat item' do
+            expect(subject).not_to have_css ".slat-item[data-toggle='tooltip']"
+          end
+        end
+      end
     end
 
     describe 'caption' do
-      let(:options) { { caption: tested_caption } }
+      let(:options) { { caption: tested_caption, tooltip: tested_tooltip } }
+      let(:tested_tooltip) { nil }
 
       context 'when caption is present' do
         let(:tested_caption) { 'tested caption' }
@@ -102,12 +161,77 @@ RSpec.describe NfgUi::Components::Elements::SlatItem do
 
           expect(subject).to have_css '.slat-item p.mb-0.font-size-sm'
         end
+
+        describe 'tooltip presence on caption slat item' do
+          context 'when tooltip is present' do
+            let(:tested_tooltip) { 'tested tooltip' }
+            it 'adds a tooltip to the caption' do
+              expect(rendered_html).to eq "<div class=\"slat-item\"><p class=\"mb-0 font-size-sm\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"#{tested_tooltip}\">#{tested_caption}</p></div>"
+
+              expect(subject).to have_css ".font-size-sm[data-toggle='tooltip']"
+            end
+          end
+
+          context 'when tooltip is not present' do
+            let(:tested_tooltip) { nil }
+            it 'does not add the tooltip html to the caption markup' do
+              expect(subject).not_to have_css ".font-size-sm[data-toggle='tooltip']"
+            end
+          end
+        end
       end
 
       context 'when caption is not present' do
         let(:tested_caption) { nil }
         it 'does not render the slat item with a caption' do
           expect(subject).not_to have_css '.slat-item p.mb-0.font-size-sm'
+        end
+      end
+    end
+
+    describe 'complex tooltip implementations' do
+      let(:options) { { heading: tested_heading, body: tested_body, caption: tested_caption, tooltip: tested_tooltip } }
+      let(:tested_tooltip) { 'tested tooltip' }
+      let(:tested_heading) { nil }
+      let(:tested_body) { nil }
+      let(:tested_caption) { nil }
+
+      describe 'heading as the anchored element' do
+        context 'when heading, body and caption are present' do
+          let(:tested_heading) { 'tested heading' }
+          let(:tested_body) { 'tested body' }
+          let(:tested_caption) { 'tested caption' }
+
+          it 'adds a tooltip to the heading only' do
+            expect(rendered_html).to eq "<div class=\"slat-item\"><h6 data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"#{tested_tooltip}\">#{tested_heading}</h6>#{tested_body}<p class=\"mb-0 font-size-sm\">#{tested_caption}</p></div>"
+          end
+        end
+
+        context 'when heading and caption are present' do
+          let(:tested_heading) { 'tested heading' }
+          let(:tested_caption) { 'tested caption' }
+          it 'adds a tooltip to the heading only' do
+            expect(rendered_html).to eq "<div class=\"slat-item\"><h6 data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"#{tested_tooltip}\">#{tested_heading}</h6><p class=\"mb-0 font-size-sm\">#{tested_caption}</p></div>"
+          end
+        end
+
+        context 'when heading and body are present' do
+          let(:tested_heading) { 'tested heading' }
+          let(:tested_body) { 'tested body' }
+          it 'adds a tooltip to the heading only' do
+            expect(rendered_html).to eq "<div class=\"slat-item\"><h6 data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"#{tested_tooltip}\">#{tested_heading}</h6>#{tested_body}</div>"
+          end
+        end
+      end
+
+      describe 'caption as the anchored element' do
+        context 'when caption and body are present' do
+          let(:tested_caption) { 'tested caption' }
+          let(:tested_body) { 'tested body' }
+
+          it 'adds a tooltip to the caption' do
+            expect(rendered_html).to eq "<div class=\"slat-item\">#{tested_body}<p class=\"mb-0 font-size-sm\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"#{tested_tooltip}\">#{tested_caption}</p></div>"
+          end
         end
       end
     end

--- a/spec/support/helpers/tooltip.rb
+++ b/spec/support/helpers/tooltip.rb
@@ -11,6 +11,5 @@
 # This then adds the '#' symbol in front of the value to return
 # a valid CSS ID selector, ex: '#tooltip41235'
 def tooltip_id(selector:)
-  return '' unless page.find(selector)['aria-describedby']
   "##{page.find(selector)['aria-describedby']}"
 end

--- a/spec/test_app/app/views/feature_spec_views/tooltip.html.haml
+++ b/spec/test_app/app/views/feature_spec_views/tooltip.html.haml
@@ -91,26 +91,42 @@
 
 %hr
 
-= ui.nfg :typeface, subheading: 'Slat Actions', class: 'mb-1'
+= ui.nfg :typeface, subheading: 'Slat Item & Slat Actions', class: 'mb-1'
 
--# Slat action inherits from dropdown item. Not assuming they are 1:1, however.
-= ui.nfg :slat_actions, describe: 'slat-actions-menu' do
+= ui.nfg :slats do
+  = ui.nfg :slat_header do
+    = ui.nfg :slat do
+      = ui.nfg :slat_body do
+        = ui.nfg :slat_item, slat_header: 'First Column', tooltip: feature_spec_tooltip_text, describe: 'tooltip-slat-header'
+        = ui.nfg :slat_item, slat_header: 'Second Column'
+        = ui.nfg :slat_item, slat_header: 'Third Column'
+        = ui.nfg :slat_item, slat_header: 'Fourth Column'
 
-  -# Slat action without href
-  = ui.nfg :slat_action, body: 'Tooltip Slat Action - No Href', icon: 'rocket', tooltip: feature_spec_tooltip_text, describe: 'tooltip-slat-action'
+    = ui.nfg :slat do
+      = ui.nfg :slat_body do
+        = ui.nfg :slat_item, heading: 'First Column Heading', href: '#nogo', tooltip: feature_spec_tooltip_text, describe: 'tooltip-slat-heading'
+        = ui.nfg :slat_item, heading: 'Second Column Heading', body: 'Second Column Body', caption: 'Second Column Caption', tooltip: feature_spec_tooltip_text, describe: 'tooltip-full-slat-item'
+        = ui.nfg :slat_item, body: 'Third Column Body', tooltip: feature_spec_tooltip_text, describe: 'tooltip-body-slat-item'
+        = ui.nfg :slat_item, caption: 'Fourth Column Caption', tooltip: feature_spec_tooltip_text, describe: 'tooltip-caption-slat-item'
 
-  -# Slat action with href
-  = ui.nfg :slat_action, body: 'Tooltip Slat Action - With Href', icon: 'rocket', tooltip: feature_spec_tooltip_text, href: '#', describe: 'tooltip-slat-action-with-href'
+      -# Slat action inherits from dropdown item. Not assuming they are 1:1, however.
+      = ui.nfg :slat_actions, describe: 'slat-actions-menu' do
 
-  -# Slat action with tooltip and with nil modal
-  -# Modal and tooltip are not allowed to both be present
-  -# at the same time. This helps ensure that the :modal key
-  -# is still acceptable, even if nil (as it should be).
-  = ui.nfg :slat_action, body: 'Tooltip Slat Action - With Nil Tooltip', icon: 'rocket', tooltip: feature_spec_tooltip_text, describe: 'modal-slat-action-with-tooltip', modal: ('#test_modal' if 1!=1)
+        -# Slat action without href
+        = ui.nfg :slat_action, body: 'Tooltip Slat Action - No Href', icon: 'rocket', tooltip: feature_spec_tooltip_text, describe: 'tooltip-slat-action'
 
-  -# Disabled slat action with tooltip
-  %span{ data: { describe: 'disabled-slat-action-wrapper' } }
-    = ui.nfg :slat_action, :disabled, body: 'Disabled Tooltip Slat Action - No Href', icon: 'rocket', tooltip: feature_spec_tooltip_text, describe: 'disabled-slat-action'
+        -# Slat action with href
+        = ui.nfg :slat_action, body: 'Tooltip Slat Action - With Href', icon: 'rocket', tooltip: feature_spec_tooltip_text, href: '#', describe: 'tooltip-slat-action-with-href'
+
+        -# Slat action with tooltip and with nil modal
+        -# Modal and tooltip are not allowed to both be present
+        -# at the same time. This helps ensure that the :modal key
+        -# is still acceptable, even if nil (as it should be).
+        = ui.nfg :slat_action, body: 'Tooltip Slat Action - With Nil Tooltip', icon: 'rocket', tooltip: feature_spec_tooltip_text, describe: 'modal-slat-action-with-tooltip', modal: ('#test_modal' if 1!=1)
+
+        -# Disabled slat action with tooltip
+        %span{ data: { describe: 'disabled-slat-action-wrapper' } }
+          = ui.nfg :slat_action, :disabled, body: 'Disabled Tooltip Slat Action - No Href', icon: 'rocket', tooltip: feature_spec_tooltip_text, describe: 'disabled-slat-action'
 %hr
 
 = ui.nfg :typeface, subheading: 'Steps', class: 'mb-1'

--- a/spec/test_app/app/views/patterns/slats/index.html.haml
+++ b/spec/test_app/app/views/patterns/slats/index.html.haml
@@ -6,15 +6,18 @@
     = ui.nfg :slat_header do
       = ui.nfg :slat do
         = ui.nfg :slat_body do
-          = ui.nfg :slat_item, slat_header: 'First Column'
-          = ui.nfg :slat_item, slat_header: 'Second Column'
-          = ui.nfg :slat_item, slat_header: 'Third Column'
+          = ui.nfg :slat_item, slat_header: 'First Column', tooltip: 'Tooltip example on slat_header'
+          = ui.nfg :slat_item, slat_header: 'Second Column', tooltip: 'Tooltip example on slat_header'
+          = ui.nfg :slat_item, slat_header: 'Third Column', tooltip: 'Tooltip example on slat_header'
+          = ui.nfg :slat_item, slat_header: 'Fourth Column', tooltip: 'Tooltip example on slat_header'
     = ui.nfg :slat do
       = ui.nfg :slat_body do
-        = ui.nfg :slat_item, heading: 'Karl Fergood - Link', href: '#nogo'
-        = ui.nfg :slat_item, slat_header: 'Second Column' do
+        = ui.nfg :slat_item, heading: 'Karl Fergood - Link', href: '#nogo', tooltip: 'Tooltip example on heading'
+        = ui.nfg :slat_item, heading: 'Second2 Column', tooltip: 'Tooltip example on heading only (not body)' do
           = ui.nfg :typeface, :truncate, body: 'aReallyLongStringForTruncationExampleIsPlacedHereAndBecauseItsGreatToStressTestItsEvenLonger!', class: 'mb-0'
-        = ui.nfg :slat_item, slat_header: 'Third Column', heading: '$5000', caption: 'An amount caption'
+        = ui.nfg :slat_item, heading: 'Third Column', heading: '$5000', caption: 'An amount caption', tooltip: 'Tooltip on heading, not caption'
+        = ui.nfg :slat_item, tooltip: 'Tooltip on rendered block body' do
+          Example for tooltip
       = ui.nfg :slat_actions do
         = ui.nfg :slat_action, href: '#', body: 'Edit', icon: 'pencil'
         = ui.nfg :slat_action, :danger, href: '#', body: 'Delete', icon: 'trash-o', method: :delete, confirm: 'Are you sure you want to delete?'


### PR DESCRIPTION
I added a custom implementation of tooltips to the slat item component. Instead of using the Tooltipable module, I went with a custom implementation. I wrote specs to back this up.

The main goal was, really, to add tooltips to slat headers (that's what spurned this feature update). But once I saw how tooltips were centered over the top of the block element they were placed on, I wanted to rework them a bit. So slat items get a unique implementation of tooltips.