### PR TITLE
DM-8192 Omits margin left class from icon if there's no body/block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.11.14
+* Fixes nfg_ui `Button` icon usage where a button without text (with an icon) would add a spacer class to the icon even when there was no text.
+
 ## 0.11.13
 * Addresses security vulnerability [CVE-2021-22880](https://github.com/advisories/GHSA-8hc4-xxm3-5ppp) by bumping `activerecord` from `5.2.4.4` to `5.2.4.5`
   * Essentially: bumps `rails` to `5.2.4.5`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.11.13)
+    nfg_ui (0.11.14)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/lib/nfg_ui/components/elements/button.rb
+++ b/lib/nfg_ui/components/elements/button.rb
@@ -70,7 +70,7 @@ module NfgUi
         private
 
         def left_icon_component
-          NfgUi::Components::Foundations::Icon.new({traits: [left_icon],
+          NfgUi::Components::Foundations::Icon.new({ traits: [left_icon],
                                                      class: NfgUi::Components::Foundations::Icon::LEFT_ICON_SPACER_CSS_CLASS },
                                                    view_context).render
 

--- a/lib/nfg_ui/components/elements/button.rb
+++ b/lib/nfg_ui/components/elements/button.rb
@@ -43,12 +43,14 @@ module NfgUi
         end
 
         def render
+          @body = yield if block_given?
+
           if tooltip && disabled
             content_tag(:span, disabled_component_tooltip_wrapper_html_options) do
               content_tag(as, html_options) do
                 capture do
                   concat(left_icon_component) if left_icon
-                  concat(block_given? ? yield : body)
+                  concat(body)
                   concat(right_icon_component) if icon
                 end
               end
@@ -58,7 +60,7 @@ module NfgUi
             content_tag(as, html_options) do
               capture do
                 concat(left_icon_component) if left_icon
-                concat(block_given? ? yield : body)
+                concat(body)
                 concat(right_icon_component) if icon
               end
             end
@@ -68,7 +70,7 @@ module NfgUi
         private
 
         def left_icon_component
-          NfgUi::Components::Foundations::Icon.new({ traits: [left_icon],
+          NfgUi::Components::Foundations::Icon.new({traits: [left_icon],
                                                      class: NfgUi::Components::Foundations::Icon::LEFT_ICON_SPACER_CSS_CLASS },
                                                    view_context).render
 
@@ -76,8 +78,12 @@ module NfgUi
 
         def right_icon_component
           NfgUi::Components::Foundations::Icon.new({ traits: [icon, :right],
-                                                     class: NfgUi::Components::Foundations::Icon::RIGHT_ICON_SPACER_CSS_CLASS },
+                                                     class: right_icon_class },
                                                    view_context).render
+        end
+
+        def right_icon_class
+          NfgUi::Components::Foundations::Icon::RIGHT_ICON_SPACER_CSS_CLASS if body.present?
         end
 
         def base_element

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.11.13'
+  VERSION = '0.11.14'
 end

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (0.11.13)
+    nfg_ui (0.11.14)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/spec/lib/nfg_ui/components/elements/button_spec.rb
+++ b/spec/lib/nfg_ui/components/elements/button_spec.rb
@@ -14,5 +14,35 @@ RSpec.describe NfgUi::Components::Elements::Button do
 
   it { expect(described_class.included_modules).to include NfgUi::Components::Utilities::Traitable }
 
-  pending 'button spec needs specs'
+  describe '#render' do
+    let(:rendered_html) { button.render }
+
+    context 'when icon is passed' do
+      let(:icon) { 'close' }
+      let(:body) { nil }
+      let(:options) {{ icon: icon, body: body }}
+
+      context 'when body is blank and no block is used' do
+        it "doesn't include an ml-1 class on the i tag" do
+          expect(rendered_html).to eq "<a class=\"btn btn-primary\" href=\"#\"><i aria-hidden=\"true\" class=\"fa fa-#{icon}\"></i></a>"
+        end
+      end
+
+      context 'when body is present' do
+        let(:body) { 'Cancel' }
+
+        it "includes an ml-1 class on the i tag" do
+          expect(rendered_html).to eq "<a class=\"btn btn-primary\" href=\"#\">#{body}<i aria-hidden=\"true\" class=\"fa fa-#{icon} ml-1\"></i></a>"
+        end
+      end
+
+      context 'when a block is used' do
+        let(:rendered_html) { button.render { 'Block' }}
+
+        it "includes an ml-1 class on the i tag" do
+          expect(rendered_html).to eq "<a class=\"btn btn-primary\" href=\"#\">Block<i aria-hidden=\"true\" class=\"fa fa-#{icon} ml-1\"></i></a>"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This isn't an urgent issue, but something I ran into today and thought I'd try and fix up.  We only need to put left margin on the (right) icon if there's text/html to display beside it.  Otherwise it throws off spacing a bit.