### PR TITLE
Feature/pstwo 17409 tile collapse icon should swap when expanded and collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## 0.12.3
 * Fixes collapsible tiles to utilize a hot-swapped up/down caret when collapsed and expanded. This was programmed in via javascript long ago but never actually worked.
+* Updates `TileHeader` to leverage a context specific collapsible icon when the component is rendered (ex: when collapsed, it is `fa-caret-down` indicating that the tile can be expanded... when expanded `.fa-caret-up` indicates that it can be collapsed).
 
 ## 0.12.2
 * Updates the bee editor CSS styles to use more accurate combinator selectors and adds styles specific if there are buttons above the bee editor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.12.3
+* Fixes collapsible tiles to utilize a hot-swapped up/down caret when collapsed and expanded. This was programmed in via javascript long ago but never actually worked.
+
 ## 0.12.2
 * Updates the bee editor CSS styles to use more accurate combinator selectors and adds styles specific if there are buttons above the bee editor.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.12.2)
+    nfg_ui (0.12.3)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/app/assets/javascripts/nfg_ui/collapsible_toggle.coffee
+++ b/app/assets/javascripts/nfg_ui/collapsible_toggle.coffee
@@ -1,3 +1,6 @@
+if typeof NfgUi == "undefined"
+  window.NfgUi = {}
+
 class NfgUi.CollapsibleToggle
   constructor: (@el) ->
     @target = @collapseTarget()

--- a/lib/nfg_ui/components/patterns/tile_header.rb
+++ b/lib/nfg_ui/components/patterns/tile_header.rb
@@ -23,7 +23,7 @@ module NfgUi
                     NfgUi::Components::Foundations::Typeface.new({ heading: title, icon: icon, class: 'h4' }, view_context).render
                   })
                   concat(content_tag(:div, class: 'col-2 text-right') {
-                    NfgUi::Components::Foundations::Icon.new({ traits: ["#{collapse_icon} fw"], tooltip: 'Show / hide additional information' }, view_context).render
+                    NfgUi::Components::Foundations::Icon.new({ traits: ["#{contextual_collapse_icon} fw"], tooltip: 'Show / hide additional information' }, view_context).render
                   })
                 end
               })
@@ -36,6 +36,11 @@ module NfgUi
         end
 
         private
+
+        def contextual_collapse_icon
+          return '' unless collapsible
+          collapsed ? collapsed_icon : collapse_icon
+        end
 
         def collapse_icon
           'caret-up'

--- a/lib/nfg_ui/components/patterns/tile_header.rb
+++ b/lib/nfg_ui/components/patterns/tile_header.rb
@@ -17,13 +17,13 @@ module NfgUi
         def render
           super do
             if collapsible && title
-              concat(NfgUi::Components::Elements::Button.new({ traits: [:link, :block], collapse: collapse, class: 'no-link-color p-0 m-0' }, view_context).render {
+              concat(NfgUi::Components::Elements::Button.new({ traits: [:link, :block], collapse: collapse, class: 'no-link-color p-0 m-0', data: { collapse_icon: collapse_icon, collapsed_icon: collapsed_icon } }, view_context).render {
                 content_tag(:div, class: 'row align-items-center') do
                   concat(content_tag(:div, class: 'col-10 text-left') {
                     NfgUi::Components::Foundations::Typeface.new({ heading: title, icon: icon, class: 'h4' }, view_context).render
                   })
                   concat(content_tag(:div, class: 'col-2 text-right') {
-                    NfgUi::Components::Foundations::Icon.new({ traits: ['caret-down fw'], tooltip: 'Show / hide additional information' }, view_context).render
+                    NfgUi::Components::Foundations::Icon.new({ traits: ["#{collapse_icon} fw"], tooltip: 'Show / hide additional information' }, view_context).render
                   })
                 end
               })
@@ -33,6 +33,16 @@ module NfgUi
 
             concat((block_given? ? yield : body))
           end
+        end
+
+        private
+
+        def collapse_icon
+          'caret-up'
+        end
+
+        def collapsed_icon
+          'caret-down'
         end
       end
     end

--- a/lib/nfg_ui/components/patterns/tile_header.rb
+++ b/lib/nfg_ui/components/patterns/tile_header.rb
@@ -23,7 +23,7 @@ module NfgUi
                     NfgUi::Components::Foundations::Typeface.new({ heading: title, icon: icon, class: 'h4' }, view_context).render
                   })
                   concat(content_tag(:div, class: 'col-2 text-right') {
-                    NfgUi::Components::Foundations::Icon.new({ traits: ["#{contextual_collapse_icon} fw"], tooltip: 'Show / hide additional information' }, view_context).render
+                    NfgUi::Components::Foundations::Icon.new({ traits: ["#{contextual_collapsible_icon} fw"], tooltip: 'Show / hide additional information' }, view_context).render
                   })
                 end
               })
@@ -37,7 +37,7 @@ module NfgUi
 
         private
 
-        def contextual_collapse_icon
+        def contextual_collapsible_icon
           return '' unless collapsible
           collapsed ? collapsed_icon : collapse_icon
         end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.12.2'
+  VERSION = '0.12.3'
 end

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (0.12.2)
+    nfg_ui (0.12.3)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/spec/features/nfg_ui/collapsible_tile_interactions_spec.rb
+++ b/spec/features/nfg_ui/collapsible_tile_interactions_spec.rb
@@ -29,5 +29,15 @@ RSpec.describe 'Collapsible tile interactions', js: true do
       expect(page).not_to have_css ".tile-header [data-toggle='collapse'] .fa-caret-up"
       expect(page).to have_css ".tile-header [data-toggle='collapse'] .fa-caret-down"
     end
+
+    and_by 'clicking the toggle' do
+      page.find("a[data-toggle='collapse']").click
+      sleep 1
+    end
+
+    and_it 'correctly expands' do
+      expect(page).to have_css ".tile-header [data-toggle='collapse'] .fa-caret-up"
+      expect(page).not_to have_css ".tile-header [data-toggle='collapse'] .fa-caret-down"
+    end
   end
 end

--- a/spec/features/nfg_ui/collapsible_tile_interactions_spec.rb
+++ b/spec/features/nfg_ui/collapsible_tile_interactions_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Collapsible tile interactions', js: true do
+  before { visit tile_feature_spec_views_path }
+
+  it 'shows the collapse icon in the correct up/down orientation' do
+    and_it 'shows the collapse icon in the collapse orientation when the tile is expanded' do
+      # indicates it's not collapsed
+      expect(page).to have_css "#collapse_tile.collapse.show"
+
+      # shows correct data attributes and has correct icon
+      expect(page).to have_css ".tile-header [data-toggle='collapse'][data-collapse-icon='caret-up'][data-collapsed-icon='caret-down'] .fa-caret-up"
+    end
+
+    and_by 'clicking the toggle' do
+      page.find("a[data-toggle='collapse']").click
+      sleep 1
+    end
+
+    and_it 'collapses the tile' do
+      # sanity check, the div is hidden visually
+      expect(page).to have_css "#collapse_tile.collapse", visible: false
+
+      # .show is removed to collapse the component
+      expect(page).not_to have_css "#collapse_tile.collapse.show"
+    end
+
+    and_it 'swaps the component' do
+      expect(page).not_to have_css ".tile-header [data-toggle='collapse'] .fa-caret-up"
+      expect(page).to have_css ".tile-header [data-toggle='collapse'] .fa-caret-down"
+    end
+  end
+end

--- a/spec/test_app/app/controllers/feature_spec_views_controller.rb
+++ b/spec/test_app/app/controllers/feature_spec_views_controller.rb
@@ -3,4 +3,5 @@ class FeatureSpecViewsController < ApplicationController
   
   def modal; end
   def tooltip; end
+  def tile; end
 end

--- a/spec/test_app/app/views/feature_spec_views/tile.html.haml
+++ b/spec/test_app/app/views/feature_spec_views/tile.html.haml
@@ -1,0 +1,2 @@
+= ui.nfg :tile, title: 'Collapsible Tile', icon: 'rocket', class: 'my-4', collapsible: true, id: 'tile' do
+  Collapsible tile

--- a/spec/test_app/config/routes.rb
+++ b/spec/test_app/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   resource :feature_spec_views do
     get :modal
     get :tooltip
+    get :tile
   end
 
   resource :javascript_plugins, only: [] do


### PR DESCRIPTION
Tiles have always been collapsible... and they've always supported hot-swappable icons for caret-up/down when collapsed and expanded... but we were missing the data attributes in the collapsable button to make that happen. Tiles are now accurately reflecting their up/down status in their toggle icon when collapsible.