### PR TITLE
Feature/dm 8657 move preview and send test email on build step to decrease height of top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.12.9
+* CSS: Fixes `z-index` is too low issue on the builder header
+* CSS: Fixes `.btn-secondary` disabled CSS styles.
+
 ## 0.12.8
 * `NavLink` was unable to accept `method: :delete` in its options hash and was breaking a logout button in Donor Management. `NavLink` is now set to `include NfgUi::Components::Utilities::Methodable`.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.12.8)
+    nfg_ui (0.12.9)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_builder_layout.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_builder_layout.scss
@@ -21,7 +21,7 @@ $builder-preview-padding: ($spacer * 1.5);
   width: 100%;
   min-height: $builder-header-height;
   background-color: $blue-700;
-  z-index: $zindex-fixed;
+  z-index: $zindex-fixed + 1;
   @include media-breakpoint-up(lg) {
     position: fixed;
     top: 0;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_buttons.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/nfg_theme/_buttons.scss
@@ -44,6 +44,12 @@
     color: $body-color !important;
     background-color: $body-bg;
   }
+  &.disabled,
+  &:disabled {
+    color: $primary;
+    background-color: $white;
+    border: $border-width solid $border-color;
+  }
 }
 .btn-link {
   font-weight: $btn-font-weight;

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.12.8'
+  VERSION = '0.12.9'
 end

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (0.12.8)
+    nfg_ui (0.12.9)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)


### PR DESCRIPTION
Fixes z-index issue on builder header and fixes btn-secondary disabled styles.
![Screen Shot 2021-07-27 at 3 18 24 PM](https://user-images.githubusercontent.com/16546623/127214634-cfeb2f7f-dba2-4dcd-bc35-e71c28549a85.png)

DM PR: https://github.com/network-for-good/donor_management/pull/2404
Onboarder PR: https://github.com/network-for-good/nfg_onboarder/pull/68
NFG UI PR: https://github.com/network-for-good/nfg_ui/pull/119

## Please make sure of the following before merging

- [x] You've provided full spec coverage for all changes
- [x] The version has been bumped up appropriately for nfg_ui and the contained publisher app
- [x] The changelog includes the version update as well as a summary of updates
- [x] The [nfg_ui_display_app](https://github.com/network-for-good/nfg_ui_display_app) has an associated PR and all component updates are accurately recorded and reflected in the display app.