### PR TITLE
Feature/dm 8744 convert tasks to nfg UI

### DIFF
--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_custom.scss
@@ -20,5 +20,6 @@
 @import 'custom/sortable';
 @import 'custom/status_indicator';
 @import 'custom/sys_only_functionality';
+@import 'custom/task';
 @import 'custom/tile';
 @import 'custom/video_countdown';

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_status_indicator.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_status_indicator.scss
@@ -2,7 +2,7 @@
 .status-indicator {
   position: absolute;
   top: -($spacer * .5);
-  right: -($spacer * .5);
+  left: -($spacer * .5);
   display: block;
   z-index: 100;
   font-size: $font-size-base;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_task.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/custom/_task.scss
@@ -1,0 +1,20 @@
+// Styles related to the task page in DM
+
+.task {
+  &.selected {
+    border-color: $input-focus-border-color;
+    box-shadow: 0 0 0 ($spacer * .125) transparentize($primary, 0.8);
+  }
+  &.task-completed {
+    background-color: $body-bg;
+    .media-body {
+      color: $text-muted;
+      [class*='text-'] { color: $text-muted !important; }
+    }
+    .badge {
+      color: $text-muted;
+      background-color: $input-disabled-bg;
+      border-color: $border-color;
+    }
+  }
+}


### PR DESCRIPTION
Moves and cleans up styles for tasks to nfg ui. Also, moves the status-indicator badge to the top left rather than top right.

## Please make sure of the following before merging

- [ ] You've provided full spec coverage for all changes
- [ ] The version has been bumped up appropriately for nfg_ui and the contained publisher app
- [ ] The changelog includes the version update as well as a summary of updates
- [ ] The [nfg_ui_display_app](https://github.com/network-for-good/nfg_ui_display_app) has an associated PR and all component updates are accurately recorded and reflected in the display app.