### PR TITLE
Feature/aio 956 update breadcrumbs and tab accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   * It now accepts the `:href` option and correctly nests an `<a>` tag.
   * The `NfgUi` version also accepts the `:active` trait and no longer requires `active: true` as the only way to activate a `BreadcrumbItem`
 * Assistive HTML attributes for tabular navigation has been updated:
-  * `Nav` now includes `role='tab-list'` when `tabs: true` in the `:options` hash
+  * `Nav` now includes `role='tablist'` when `tabs: true` in the `:options` hash
   * `NavItem` now includes `role='tab'` (moved from `NavLink`) when `:tab` is included in the `:options` hash
 
 ## 0.14.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * `BreadcrumbItem` has been updated in `Bootstrap` & `NfgUi`:
   * It now accepts the `:href` option and correctly nests an `<a>` tag.
   * The `NfgUi` version also accepts the `:active` trait and no longer requires `active: true` as the only way to activate a `BreadcrumbItem`
+* Assistive HTML attributes for tabular navigation has been updated:
+  * `Nav` now includes `role='tab-list'` when `tabs: true` in the `:options` hash
+  * `NavItem` now includes `role='tab'` (moved from `NavLink`) when `:tab` is included in the `:options` hash
 
 ## 0.14.0.1
 * Adds missing dependabot security fixes: `Rails` and associated packages are upgraded to `5.2.7.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.14.1
+* `BreadcrumbItem` has been updated in `Bootstrap` & `NfgUi`:
+  * It now accepts the `:href` option and correctly nests an `<a>` tag.
+  * The `NfgUi` version also accepts the `:active` trait and no longer requires `active: true` as the only way to activate a `BreadcrumbItem`
+
 ## 0.14.0.1
 * Adds missing dependabot security fixes: `Rails` and associated packages are upgraded to `5.2.7.1`
 * Updates `publisher` app to use ruby 2.7.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (0.14.0.1)
+    nfg_ui (0.14.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/lib/nfg_ui/bootstrap/components/breadcrumb_item.rb
+++ b/lib/nfg_ui/bootstrap/components/breadcrumb_item.rb
@@ -13,6 +13,22 @@ module NfgUi
           :breadcrumb
         end
 
+        def render
+          if href
+            # remove href from options hash so it does not
+            # get added to the parent element -- and instead
+            # gets stored so we can use it to build the
+            # inserted <a> tag.
+            delegated_href = options.delete(:href)
+
+            super do
+              view_context.link_to(body, delegated_href)
+            end
+          else
+            super
+          end
+        end
+
         private
 
         def base_element

--- a/lib/nfg_ui/bootstrap/components/nav.rb
+++ b/lib/nfg_ui/bootstrap/components/nav.rb
@@ -35,6 +35,11 @@ module NfgUi
 
         private
 
+        def assistive_html_attributes
+          return super unless tabs
+          super.merge(role: 'tab-list')
+        end
+
         def base_element
           as
         end

--- a/lib/nfg_ui/bootstrap/components/nav.rb
+++ b/lib/nfg_ui/bootstrap/components/nav.rb
@@ -37,7 +37,7 @@ module NfgUi
 
         def assistive_html_attributes
           return super unless tabs
-          super.merge(role: 'tab-list')
+          super.merge(role: 'tablist')
         end
 
         def base_element

--- a/lib/nfg_ui/bootstrap/components/nav_item.rb
+++ b/lib/nfg_ui/bootstrap/components/nav_item.rb
@@ -66,6 +66,11 @@ module NfgUi
 
         private
 
+        def assistive_html_attributes
+          return super unless tab
+          super.merge(role: 'tab')
+        end
+
         def base_element
           as
         end

--- a/lib/nfg_ui/bootstrap/components/nav_link.rb
+++ b/lib/nfg_ui/bootstrap/components/nav_link.rb
@@ -50,7 +50,7 @@ module NfgUi
 
         def assistive_html_attributes
           return super unless tab
-          { role: 'tab', aria: { controls: tab.tr('#', ''), selected: active } }
+          { aria: { controls: tab.tr('#', ''), selected: active } }
         end
       end
     end

--- a/lib/nfg_ui/components/elements/breadcrumb_item.rb
+++ b/lib/nfg_ui/components/elements/breadcrumb_item.rb
@@ -10,6 +10,8 @@ module NfgUi
         include NfgUi::Components::Utilities::Traitable
         include NfgUi::Components::Utilities::Describable
         include NfgUi::Components::Utilities::Renderable
+
+        include NfgUi::Components::Traits::Active
       end
     end
   end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '0.14.0.1'
+  VERSION = '0.14.1'
 end

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (0.14.0.1)
+    nfg_ui (0.14.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/spec/lib/nfg_ui/bootstrap/components/breadcrumb_item_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/breadcrumb_item_spec.rb
@@ -14,6 +14,27 @@ RSpec.describe NfgUi::Bootstrap::Components::BreadcrumbItem do
     it { is_expected.to eq :breadcrumb }
   end
 
+  describe '#render' do
+    subject { breadcrumb_item.render }
+    let(:test_body) { 'Breadcrumb Text' }
+    let(:options) { { href: test_link, body: test_body } }
+
+    context 'when :href is present in options' do
+      let(:test_link) { '#link' }
+
+      it 'renders the <li> with a nested <a> link' do
+        expect(subject).to eq "<li class=\"breadcrumb-item\"><a href=\"#{test_link}\">#{test_body}</a></li>"
+      end
+    end
+
+    context 'when :href is not present in options' do
+      let(:test_link) { nil }
+      it 'renders the <li> only' do
+        expect(subject).to eq "<li class=\"breadcrumb-item\">#{test_body}</li>"
+      end
+    end
+  end
+
   describe 'private methods' do
     describe '#assistive_html_attributes' do
       subject { breadcrumb_item.send(:assistive_html_attributes) }

--- a/spec/lib/nfg_ui/bootstrap/components/nav_item_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/nav_item_spec.rb
@@ -226,4 +226,17 @@ RSpec.describe NfgUi::Bootstrap::Components::NavItem do
                                 :button,
                                 :tab) }
   end
+
+  describe '#assistive_html_attributes' do
+    let(:options) { { tab: test_tab } }
+    subject { nav_item.send(:assistive_html_attributes) }
+    context 'when :tab is present in options' do
+      let(:test_tab) { '#tab_link' }
+      it { is_expected.to include(role: 'tab') }
+    end
+    context 'when :tab is not present in options' do
+      let(:test_tab) { nil }
+      it { is_expected.not_to include(role: 'tab') }
+    end
+  end
 end

--- a/spec/lib/nfg_ui/bootstrap/components/nav_link_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/nav_link_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe NfgUi::Bootstrap::Components::NavLink do
       
       context 'when active is true in options' do
         let(:options) { { tab: tested_tab, active: true } }
-        it { is_expected.to eq(role: 'tab', aria: { controls: test_tab_word, selected: true }) }
+        it { is_expected.to eq(aria: { controls: test_tab_word, selected: true }) }
       end
 
       context 'when active is falsey in options' do
         let(:options) { { tab: tested_tab } }
-        it { is_expected.to eq(role: 'tab', aria: { controls: test_tab_word, selected: false }) }
+        it { is_expected.to eq(aria: { controls: test_tab_word, selected: false }) }
       end
     end
 

--- a/spec/lib/nfg_ui/bootstrap/components/nav_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/nav_spec.rb
@@ -207,5 +207,18 @@ RSpec.describe NfgUi::Bootstrap::Components::Nav do
                                   :pill,
                                   :vertical) }
     end
+
+    describe '#assistive_html_attributes' do
+      let(:options) { { tabs: test_tabs } }
+      subject { nav.send(:assistive_html_attributes) }
+      context 'when :tabs is true' do
+        let(:test_tabs) { true }
+        it { is_expected.to include(role: 'tab-list') }
+      end
+      context 'when :tabs is falsy' do
+        let(:test_tabs) { nil }
+        it { is_expected.not_to include(role: 'tab-list') }
+      end
+    end
   end
 end

--- a/spec/lib/nfg_ui/bootstrap/components/nav_spec.rb
+++ b/spec/lib/nfg_ui/bootstrap/components/nav_spec.rb
@@ -213,11 +213,11 @@ RSpec.describe NfgUi::Bootstrap::Components::Nav do
       subject { nav.send(:assistive_html_attributes) }
       context 'when :tabs is true' do
         let(:test_tabs) { true }
-        it { is_expected.to include(role: 'tab-list') }
+        it { is_expected.to include(role: 'tablist') }
       end
       context 'when :tabs is falsy' do
         let(:test_tabs) { nil }
-        it { is_expected.not_to include(role: 'tab-list') }
+        it { is_expected.not_to include(role: 'tablist') }
       end
     end
   end

--- a/spec/test_app/app/views/elements/breadcrumbs/index.html.haml
+++ b/spec/test_app/app/views/elements/breadcrumbs/index.html.haml
@@ -1,7 +1,8 @@
 %h1 Breadcrumbs
 
 = ui.nfg :breadcrumb, class: 'example-class' do
-  = ui.nfg :breadcrumb_item, body: 'Home', class: 'example-class'
+  = ui.nfg :breadcrumb_item, class: 'example-class', href: patterns_media_path do
+    %b Home
   -# Block example
-  = ui.nfg :breadcrumb_item, active: true, class: 'example-class' do
+  = ui.nfg :breadcrumb_item, :active, class: 'example-class' do
     Active Page

--- a/spec/views/nfg_ui/bootstrap/navs/_nav.html.haml_spec.rb
+++ b/spec/views/nfg_ui/bootstrap/navs/_nav.html.haml_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'nfg_ui/bootstrap/navs/_nav.html.haml', type: :view do
     let(:options) { { tabs: true } }
     it 'outputs a nav with tabs' do
       expect(subject).to have_css '.nav.nav-tabs'
-      expect(subject).to eq "<ul class=\"nav nav-tabs\" role=\"tab-list\">#{body}</ul>"
+      expect(subject).to eq "<ul class=\"nav nav-tabs\" role=\"tablist\">#{body}</ul>"
     end
   end
 

--- a/spec/views/nfg_ui/bootstrap/navs/_nav.html.haml_spec.rb
+++ b/spec/views/nfg_ui/bootstrap/navs/_nav.html.haml_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'nfg_ui/bootstrap/navs/_nav.html.haml', type: :view do
     let(:options) { { tabs: true } }
     it 'outputs a nav with tabs' do
       expect(subject).to have_css '.nav.nav-tabs'
-      expect(subject).to eq "<ul class=\"nav nav-tabs\">#{body}</ul>"
+      expect(subject).to eq "<ul class=\"nav nav-tabs\" role=\"tab-list\">#{body}</ul>"
     end
   end
 

--- a/spec/views/nfg_ui/bootstrap/navs/_nav_item.html.haml_spec.rb
+++ b/spec/views/nfg_ui/bootstrap/navs/_nav_item.html.haml_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'nfg_ui/bootstrap/navs/_nav_item.html.haml', type: :view do
     let(:options) { { tab: tested_tab } }
     it 'outputs a nav_item with a nav_link connected to a javascript data toggled tab' do
       expect(subject).to have_css "li.nav-item a.nav-link[aria-controls='#{tested_tab.tr('#', '')}'][data-toggle='tab']"
-      expect(subject).to eq "<li class=\"nav-item\"><a class=\"nav-link\" data-toggle=\"tab\" href=\"#{tested_tab}\" role=\"tab\" aria-controls=\"#{tested_tab.tr('#', '')}\" aria-selected=\"false\">#{body}</a></li>"
+      expect(subject).to eq "<li class=\"nav-item\" role=\"tab\"><a class=\"nav-link\" data-toggle=\"tab\" href=\"#{tested_tab}\" aria-controls=\"#{tested_tab.tr('#', '')}\" aria-selected=\"false\">#{body}</a></li>"
     end
 
     it "supplies the link's href from the :tab argument in options" do


### PR DESCRIPTION
## Please make sure of the following before merging

- [x] You've provided full spec coverage for all changes
- [x] The version has been bumped up appropriately for nfg_ui and the contained publisher app
- [x] The changelog includes the version update as well as a summary of updates
- [ ] The [nfg_ui_display_app](https://github.com/network-for-good/nfg_ui_display_app) has an associated PR and all component updates are accurately recorded and reflected in the display app.