### PR TITLE
Feature/rails 6 update collapse to apply a random id if left out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 6.15.4
+* `NfgUi::Components::Patterns::Collapse` has been updated:
+  * When "speed building" a collapse (using `:header` to create a link text that collapses and expands the collapse component), a CSS `id` is automatically generated for you if you forget to pass one in.
+    * The random CSS `:id` consists of a letter and then 6 random alphanumeric letters. Ex: `<id='a-AHfh24'>` which will automatically be passed to the collapse button toggle and the collapse component.
+  * You can now customize the `:icon` associated with the `:header` by passing in an `:icon` into options.
+    * Example: `= ui.nfg :collapse, :collapsed, body: 'Body', heading: 'Collapse heading link', icon: 'rocket'`
+
 ## 6.15.3
 * Note: We've adopted main version update to reflect the version of rails this branch works on (Rails 6)
 * Updates `DropdownItem` to accept `as: :button_to` which wraps the component in the `button_to` rails helper.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (6.15.3)
+    nfg_ui (6.15.4)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/lib/nfg_ui/components/patterns/collapse.rb
+++ b/lib/nfg_ui/components/patterns/collapse.rb
@@ -15,15 +15,41 @@ module NfgUi
 
         include NfgUi::Components::Traits::Collapse
 
+        # Because it is common to forget to add the required :id
+        # to the component options when doing a "speed built"
+        # collapse, example:
+        # = ui.nfg :collapse, :collapsed, body: 'Collapse body content', heading: 'My Link'
+        #
+        # Send in a random string that is carried through
+        # from the speed built heading / button AND
+        # to the collapse component.
+        def component_initialize
+          # Only create and supply a random ID this when a :heading is present
+          return unless heading
+          new_id = options[:id].nil? ? random_id : options[:id]
+          options[:id] = new_id
+        end
+
         def render
           capture do
             if heading
-              opts = { collapse: "##{id}", body: heading, icon: 'caret-down', class: 'pl-0 text-left' }
+              icon = options.fetch(:icon, 'caret-down')
+              opts = { collapse: "##{html_options[:id]}", body: heading, icon: icon, class: 'pl-0 text-left' }
               opts.merge!(traits: [:link, :block])
               concat(NfgUi::Components::Elements::Button.new(opts, view_context).render)
             end
             concat(super)
           end
+        end
+
+        private
+
+        # Generate a string of random letters
+        # We must insert a random letter before SecureRandom because
+        # if a css ID starts with a number, it seems to break
+        # the collapse JS functionality.
+        def random_id
+          "#{('a'..'z').to_a.sample}-#{SecureRandom.alphanumeric(6)}"
         end
       end
     end

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '6.15.3'
+  VERSION = '6.15.4'
 end

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (6.15.3)
+    nfg_ui (6.15.4)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/spec/lib/nfg_ui/components/patterns/collapse_spec.rb
+++ b/spec/lib/nfg_ui/components/patterns/collapse_spec.rb
@@ -13,5 +13,84 @@ RSpec.describe NfgUi::Components::Patterns::Collapse do
 
   it { expect(described_class.included_modules).to include NfgUi::Components::Utilities::Traitable }
 
-  pending 'collapse needs spec'
+  describe '#component_initialize' do
+    let(:test_id) { nil }
+    let(:test_heading) { nil }
+    let(:options) { { id: test_id, heading: test_heading } }
+
+    context 'when heading is not present in options' do
+      let(:test_heading) { nil }
+
+      context 'when an ID is not present' do
+        let(:test_id) { nil }
+
+        it 'does not generate an ID' do
+          expect(collapse.options[:id]).to be_nil
+        end
+      end
+
+      context 'when an ID is present' do
+        let(:test_id) { 'test-id' }
+
+        it 'does uses the options :ID' do
+          expect(collapse.options[:id]).to eq test_id
+        end
+      end
+    end
+
+    context 'when heading is present in options' do
+      let(:test_heading) { 'test heading' }
+
+      context 'when options includes an :id' do
+        let(:test_id) { 'test-id' }
+        it 'passes the id in options into the component' do
+          expect(collapse.options[:id]).to eq test_id
+        end
+      end
+
+      context 'when options does not include an :id' do
+        let(:test_id) { nil }
+        it 'supplies an :id' do
+          # it's a random set of letters so we can't really test the exact value
+          # but checking that ID is present when it's set to nil
+          # is good enough.
+          expect(Capybara.string(collapse.render)).to have_css "[id]"
+          expect(collapse.options[:id]).to be_present
+        end
+      end
+    end
+  end
+
+  describe '#render' do
+    let(:options) { { heading: test_heading, id: test_id } }
+    let(:test_heading) { nil }
+    let(:test_id) { nil }
+    let(:capybara_component) { Capybara.string(collapse.render) }
+
+    context 'when a :heading is supplied' do
+      let(:test_heading) { 'Test heading' }
+
+      context 'when an ID is not supplied' do
+        let(:test_id) { nil }
+
+        it 'renders a button and the collapse icon and a random ID' do
+          random_id = capybara_component.find('a')['aria-controls']
+          expect(capybara_component).to have_css "a[href='##{random_id}'] + .collapse##{random_id}"
+        end
+      end
+      context 'when an ID is supplied' do
+        let(:test_id) { 'test-id' }
+        it 'renders the combined components with the supplied :id' do
+          expect(capybara_component).to have_css "a[href='##{test_id}'] + .collapse##{test_id}"
+        end
+      end
+    end
+
+    context 'when a heading is not supplied' do
+      let(:test_heading) { nil }
+      it 'renders only the expected collapse component without a button' do
+        expect(collapse.render).to eq "<div class=\"collapse show\"></div>"
+      end
+    end
+  end
 end

--- a/spec/test_app/app/views/patterns/collapses/index.html.haml
+++ b/spec/test_app/app/views/patterns/collapses/index.html.haml
@@ -16,3 +16,9 @@
 %h2 collapse with heading
 
 = ui.nfg :collapse, id: 'required_id3', body: 'Body implemented via options and is collapsed. Collapse is not collapsed by default', heading: 'Collapse heading link', collapsed: true
+
+%h2 collapse with heading, custom icon and no ID
+
+= ui.nfg :collapse, body: 'Body implemented via options and is collapsed. Collapse is not collapsed by default', heading: 'Collapse heading link', collapsed: true, icon: 'rocket'
+
+= ui.nfg :collapse, body: 'Body implemented via options and is collapsed. Collapse is not collapsed by default', heading: 'Collapse heading link', collapsed: true, icon: 'rocket'


### PR DESCRIPTION
## Please make sure of the following before merging

- [ ] You've provided full spec coverage for all changes
- [ ] The version has been bumped up appropriately for nfg_ui and the contained publisher app
- [ ] The changelog includes the version update as well as a summary of updates
- [ ] The [nfg_ui_display_app](https://github.com/network-for-good/nfg_ui_display_app) has an associated PR and all component updates are accurately recorded and reflected in the display app.