### PR TITLE
Feature/aio 1902 fix underline link on buttons for public pages within nfg UI gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 5.15.8
+* CSS: Cleans up `<a>` links that aren't nav or buttons by moving the :not() outside of the nested style
+
 ## 5.15.7
 * Addresses security vulnerability [GHSA-qv4q-mr5r-qprj](https://github.com/advisories/GHSA-qv4q-mr5r-qprj) by bumping `nokogiri` to `1.13.10`.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (5.15.7)
+    nfg_ui (5.15.8)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)
@@ -294,4 +294,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.2.23
+   2.4.6

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/entity_branding/nfg_theme/_reboot.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/entity_branding/nfg_theme/_reboot.scss
@@ -2,15 +2,18 @@
 
 a {
   color: var(--brand-primary-yiq-text-dark);
-  &:not([class*="btn"], [class*="nav"]) {
-    color: var(--brand-primary-yiq-text-dark);
-    text-decoration: underline;
-    &:hover, &:focus {
-      text-decoration: none;
-    }
-  }
   .bg-dark & {
     color: $white;
     &:hover, &:focus { color: $white; }
+  }
+}
+
+// have to call out each individual instead of combining multiple elements using nested &:not(.btn, .nav-link)
+a:not(.btn, .nav-link, .dropdown-item, .page-link) {
+  color: var(--brand-primary-yiq-text-dark);
+  text-decoration: underline;
+  &:hover, &:focus {
+    color: var(--brand-primary-yiq-text-dark);
+    text-decoration: none !important;
   }
 }

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '5.15.7'
+  VERSION = '5.15.8'
 end


### PR DESCRIPTION
This fixes the underline issue on links by moving the :not() out of the nested format

## Please make sure of the following before merging

- [ ] You've provided full spec coverage for all changes
- [ ] The version has been bumped up appropriately for nfg_ui and the contained publisher app
- [ ] The changelog includes the version update as well as a summary of updates
- [ ] The [nfg_ui_display_app](https://github.com/network-for-good/nfg_ui_display_app) has an associated PR and all component updates are accurately recorded and reflected in the display app.