### PR TITLE
remove init_haml_helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 6.17.0
+* Updates HAML development dependency to `~> 6.0` after removal of HAML 5's `init_haml_helpers` method.
+
 ## 6.16.1
 * Adds Bonterra logos and partials for access in host apps.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (6.16.1)
+    nfg_ui (6.17.0)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)
@@ -120,8 +120,9 @@ GEM
     foundation_emails (2.2.1.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    haml (5.2.2)
-      temple (>= 0.8.0)
+    haml (6.1.1)
+      temple (>= 0.8.2)
+      thor
       tilt
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -263,7 +264,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
-    temple (0.8.2)
+    temple (0.10.0)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.2)

--- a/lib/nfg_ui/ui/utilities/initializer.rb
+++ b/lib/nfg_ui/ui/utilities/initializer.rb
@@ -39,7 +39,7 @@ module NfgUi
           # #init_haml_helpers is required when utilizing #capture with HAML
           # (when outside of Rails)
           # https://www.rubydoc.info/github/haml/haml/Haml%2FHelpers:init_haml_helpers
-          init_haml_helpers
+          # init_haml_helpers
           @component_name = component_name
           @class_name = component_name.to_s.camelize
           @traits = traits

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '6.16.1'
+  VERSION = '6.17.0'
 end

--- a/nfg_ui.gemspec
+++ b/nfg_ui.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   # be manually set.
   s.add_dependency 'autoprefixer-rails', '9.4.9'
 
+  s.add_development_dependency 'haml', '~> 6.0'
   s.add_development_dependency 'capybara', '~> 3.9'
   s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'factory_bot_rails', '~> 4.11'

--- a/publisher/Gemfile.lock
+++ b/publisher/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nfg_ui (6.16.1)
+    nfg_ui (6.17.0)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)


### PR DESCRIPTION
See release notes in https://github.com/haml/haml/releases/tag/v6.0.0

## Please make sure of the following before merging

- [ ] You've provided full spec coverage for all changes
- [ ] The version has been bumped up appropriately for nfg_ui and the contained publisher app
- [ ] The changelog includes the version update as well as a summary of updates
- [ ] The [nfg_ui_display_app](https://github.com/network-for-good/nfg_ui_display_app) has an associated PR and all component updates are accurately recorded and reflected in the display app.