### PR TITLE
Replace bundled logo assets with Stitch bonterra-logo web component a…

### DIFF
--- a/app/views/nfg_ui/_logo.html.haml
+++ b/app/views/nfg_ui/_logo.html.haml
@@ -1,12 +1,11 @@
+- content_for :head do
+  %script{ src: "https://cdn.bonterra.network/stitch/helpers/bonterra-logo/bonterra-logo.js", type: "module" }
+
 - bonterra = false if local_assigns[:bonterra].nil?
 
 - if bonterra
   = link_to 'https://www.bonterratech.com', title: 'Powered by Bonterra', class: 'd-inline-block text-decoration-none align-middle' do
-    = ui.nfg :image, image: "#{image_path('nfg_ui/logo/logo-symbol-indigo-bonterra.svg')}", alt: 'Powered by Bonterra', height: '16', responsive: false
-    = ui.nfg :typeface, :caption, class: 'd-inline-block mb-0' do
-      %span{ style: "color: #14022D;"}Powered by
-      %span{ style: "color: #726F76;"}Bonterra
-
+    %bonterra-logo{ name: "bonterra_logomark", alt: "Bonterra", type: "svg", size: "medium" }
 - else
-  = link_to 'http://www.networkforgood.com', target: '_blank', title: 'Network for Good. Simple. Smart. Fundraising Software.', class: 'd-inline-block' do
-    = ui.nfg :image, image: "#{image_path('nfg_ui/logo/logo-bonterra-nfg.svg')}", alt: 'Network for Good. Simple. Smart. Fundraising Software.', height: '28', responsive: false
+  = link_to 'http://www.networkforgood.com', target: '_blank', title: 'Bonterra Network for Good', class: 'd-inline-block' do
+    %bonterra-logo{ name: "bonterra_logolockups_network_for_good", alt: "Bonterra Network for Good", type: "svg", size: "large" }

--- a/app/views/nfg_ui/email/_logo.html.haml
+++ b/app/views/nfg_ui/email/_logo.html.haml
@@ -2,5 +2,5 @@
   %columns
     %spacer{ size: spacer(:double) }
     %a{ href: t('nfg_ui.email.links.nfg_website.homepage'), target: "_blank" }
-      %img.display-inline-block{ src: image_path("nfg_ui/email/nfg-bonterra-logo.png"), alt: t('nfg_ui.email.images.alt.logo'), width: "220", style: "width:220px;" }/
+      %img.display-inline-block{ src: "https://cdn.bonterra.network/stitch/logos/png/bonterra_logolockups_network_for_good_inverse.png", alt: t('nfg_ui.email.images.alt.logo'), width: "220", style: "width:220px;" }/
     %spacer{ size: spacer(:triple) }

--- a/config/locales/email.yml
+++ b/config/locales/email.yml
@@ -5,10 +5,9 @@ en:
         name: "Network for Good"
         address: "Network for Good | 1140 Connecticut Avenue NW, Suite 700, Washington, District of Columbia 20036"
       images:
-        logo: "nfg_ui/email/nfg-bonterra-logo.png"
         alt:
           caret: ">"
-          logo: "Network for Good"
+          logo: "Bonterra Network for Good"
           social:
             facebook: "Network for Good on Facebook"
             twitter: "Network for Good on Twitter"

--- a/spec/views/nfg_ui/_logo.html.haml_spec.rb
+++ b/spec/views/nfg_ui/_logo.html.haml_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe "nfg_ui/_logo", type: :view do
+  context "default (bonterra: false)" do
+    before { render partial: "nfg_ui/logo" }
+
+    it "renders the bonterra-logo web component with the NFG lockup" do
+      expect(rendered).to have_css("bonterra-logo[name='bonterra_logolockups_network_for_good']")
+    end
+
+    it "links to networkforgood.com" do
+      expect(rendered).to have_link(href: "http://www.networkforgood.com")
+    end
+  end
+
+  context "bonterra: true" do
+    before { render partial: "nfg_ui/logo", locals: { bonterra: true } }
+
+    it "renders the bonterra-logo web component with the logomark" do
+      expect(rendered).to have_css("bonterra-logo[name='bonterra_logomark']")
+    end
+
+    it "links to bonterratech.com" do
+      expect(rendered).to have_link(href: "https://www.bonterratech.com")
+    end
+  end
+end

--- a/spec/views/nfg_ui/email/_logo.html.haml_spec.rb
+++ b/spec/views/nfg_ui/email/_logo.html.haml_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "nfg_ui/email/_logo", type: :view do
+  before { render partial: "nfg_ui/email/logo" }
+
+  it "renders an img tag pointing to the Stitch Backdrop PNG" do
+    expect(rendered).to have_css(
+      "img[src='https://cdn.bonterra.network/stitch/logos/png/bonterra_logolockups_network_for_good_inverse.png']"
+    )
+  end
+
+  it "uses the updated alt text" do
+    expect(rendered).to have_css("img[alt='Bonterra Network for Good']")
+  end
+end


### PR DESCRIPTION
…nd add view specs

## Please make sure of the following before merging

- [ ] You've provided full spec coverage for all changes
- [ ] The version has been bumped up appropriately for nfg_ui and the contained publisher app
- [ ] The changelog includes the version update as well as a summary of updates
- [ ] The [nfg_ui_display_app](https://github.com/network-for-good/nfg_ui_display_app) has an associated PR and all component updates are accurately recorded and reflected in the display app.

## Title: NFG-3192: Replace logo images with Stitch bonterra-logo web component

## Body:


## Summary
- Replaces static SVG assets in `_logo.html.haml` with the `<bonterra-logo>` web component
  (NFG lockup for default, logomark for `bonterra: true` variant). Injects the Stitch CDN
  script via `content_for :head` so host app layouts pick it up with their existing `yield :head`.
- Updates `email/_logo.html.haml` to use the Stitch Backdrop PNG CDN URL instead of the
  bundled local asset — dark-mode-safe in email clients, no JS required.
- Updates `config/locales/email.yml`: removes the unused `images.logo` key, updates alt text
  to "Bonterra Network for Good".
- Adds view specs for both partials (previously had zero coverage).

## Why
Bundled SVG/PNG assets require a gem release + re-deploy across all consuming apps for every
brand update. The Stitch web component and CDN-hosted PNG always reflect current branding
without code changes.

## Test plan
- [ ] `bundle exec rspec spec/views/nfg_ui/_logo.html.haml_spec.rb spec/views/nfg_ui/email/_logo.html.haml_spec.rb`
- [ ] Boot a consuming app dev server; confirm `<bonterra-logo>` in DOM and `bonterra-logo.js` in `<head>` via DevTools
- [ ] Send a test email; confirm Backdrop PNG loads with visible background in dark mode