### PR TITLE
fix(deps): SCA upgrades — capybara, puma (nfg_ui)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,11 +104,11 @@ GEM
     browser (2.7.1)
     builder (3.3.0)
     byebug (11.1.3)
-    capybara (3.37.1)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
@@ -211,7 +211,7 @@ GEM
       date
       stringio
     public_suffix (5.0.0)
-    puma (5.6.5)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.11)
@@ -375,7 +375,7 @@ DEPENDENCIES
   nfg_ui!
   pry
   pry-byebug
-  puma (~> 5.3)
+  puma (~> 7.2)
   rails-controller-testing (~> 1.0)
   rspec-rails (~> 6.1)
   rspec_junit_formatter (~> 0.4)

--- a/nfg_ui.gemspec
+++ b/nfg_ui.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara', '~> 3.9'
   s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'factory_bot_rails', '~> 4.11'
-  s.add_development_dependency 'puma', '~> 5.3'
+  s.add_development_dependency 'puma', '~> 7.2'
   s.add_development_dependency 'rails-controller-testing', '~> 1.0' # for assert-template
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
   s.add_development_dependency 'rspec-rails', '~> 6.1'


### PR DESCRIPTION
## Security: SCA dependency upgrades

Upgrades 2 vulnerable dependencies identified via Snyk SCA scanning.

### Changes

| Library | Before | After | CVEs fixed |
|---------|--------|-------|------------|
| capybara | 3.37.1 | 3.40.0 | 15 of 18 |
| puma | 5.6.5 | 7.2.1 | 4 |

**Note on partial coverage:** 3 CVEs from NFG-3566 (CVE-2025-27610, CVE-2025-46727, CVE-2026-35611) remain in transitive deps `rack 2.2.11` and `addressable 2.8.1` — upgrading capybara does not fix those. Separate tickets required.

**Note on publisher/Gemfile.lock:** NFG-3527 (nfg_ui) and NFG-3526 (rails) target `publisher/Gemfile.lock` which requires Ruby 3.3.7. That lockfile must be updated in CI or on a machine with matching Ruby.

### Linked Jira tickets

- [NFG-3566](https://bonterra.atlassian.net/browse/NFG-3566) — capybara upgrade (SLA: July 31, 2026)
- [NFG-3556](https://bonterra.atlassian.net/browse/NFG-3556) — puma upgrade (SLA: July 31, 2026)

### References

- Snyk Project (NFG-3566): https://app.snyk.io/org/networkforgood/project/31871cfa-e704-4025-aacd-e635de282ec8#issue-SNYK-RUBY-RACK
- Snyk Project (NFG-3556): https://app.snyk.io/org/networkforgood/project/31871cfa-e704-4025-aacd-e635de282ec8#issue-SNYK-RUBY-PUMA

---
*This PR was generated by the Engineer-Application Security. Questions? Ping Travis Felder.*

[NFG-3566]: https://bonterra.atlassian.net/browse/NFG-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NFG-3556]: https://bonterra.atlassian.net/browse/NFG-3556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ