### PR TITLE
Nfg 3024 color palette update ensure aa wcag compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+##  7.3.0
+* Updates theme colors for accessibility (WCAG contrast): refreshes the blue (primary) scale, primary blue, and red; updates app icon / favicon tile colors to `#006DA8`.
+* Restricts secondary buttons to text-primary color and primary buttons to the primary color; updates nav colors and active/hover nav states.
 ##  7.2.1
 * Upgrades ruby version to 3.3.7
 ##  7.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_ui (7.2.3)
+    nfg_ui (7.3.0)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/app/assets/images/nfg_ui/app_icon/browserconfig.xml.erb
+++ b/app/assets/images/nfg_ui/app_icon/browserconfig.xml.erb
@@ -3,7 +3,7 @@
     <msapplication>
         <tile>
             <square150x150logo src="<%= image_path('nfg_ui/app_icon/mstile-150x150.png') %>"/>
-            <TileColor>#25aceb</TileColor>
+            <TileColor>#006DA8</TileColor>
         </tile>
     </msapplication>
 </browserconfig>

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_buttons.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_buttons.scss
@@ -1,17 +1,17 @@
 @each $color, $value in $colors {
   .#{$color} {
     .btn-primary {
-      @include button-variant($value, $value);
+      @include button-variant($primary, $primary);
       color: $white !important;
       &:focus,
       &.focus {
-        box-shadow: 0 0 0 $input-btn-focus-width transparentize($value, 0.8);
+        box-shadow: 0 0 0 $input-btn-focus-width transparentize($primary, 0.8);
       }
       &:not(:disabled):not(.disabled):active,
       &:not(:disabled):not(.disabled).active,
       .show > &.dropdown-toggle {
-        box-shadow: 0 0 0 $input-btn-focus-width transparentize($value, 0.8);
-        &:focus { box-shadow: 0 0 0 $input-btn-focus-width transparentize($value, 0.8); }
+        box-shadow: 0 0 0 $input-btn-focus-width transparentize($primary, 0.8);
+        &:focus { box-shadow: 0 0 0 $input-btn-focus-width transparentize($primary, 0.8); }
       }
     }
     .btn-link {
@@ -31,6 +31,6 @@
       border-color: darken($value, 10%);
       &:focus { box-shadow: 0 0 0 $input-btn-focus-width transparentize($value, 0.8); }
     }
-    .btn-secondary, .btn-outline-secondary, .btn-link { color: $value; }
+    .btn-secondary, .btn-outline-secondary, .btn-link { color: $yiq-text-dark; }
   }
 }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_nav.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/color_variations/nfg_theme/_nav.scss
@@ -3,7 +3,7 @@
     .nav-tabs {
       .nav-link {
         &:hover, &.active {
-          &:after { background: $value; }
+          &:after { background: $primary; }
         }
       }
     }
@@ -14,7 +14,7 @@
     .nav-item.#{$color} {
       .nav-link {
         &:hover, &.active, &[aria-expanded="true"] {
-          &:after { background-color: $value; }
+          &:after { background-color: $primary; }
         }
       }
     }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_nav.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/admin/nfg_theme/_nav.scss
@@ -4,7 +4,7 @@
   top: 0;
   width: 200px;
   height: 100%;
-  background-color: $blue-700;
+  background-color: $blue-600;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   @include transition(all .2s ease-in-out);

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/_variables.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/_variables.scss
@@ -40,11 +40,11 @@ $black:    #000000;
 //   $grays
 // );
 
-$blue:    #25aceb;
+$blue:    #006DA8;
 // $indigo:  #6610f2 !default; // not used in our theme
 // $purple:  #6f42c1 !default; // not used in our theme
 // $pink:    #e83e8c !default; // not used in our theme
-$red:     #ff6d33;
+$red:     #D92C2C;
 $orange:  #ffaa00;
 // $yellow:  #ffc107 !default; // not used in our theme
 $green:   #59bf22;
@@ -74,15 +74,15 @@ $green:   #59bf22;
 
 
 // Blue (primary) scale
-$blue-100: #d3eefb;
-$blue-200: #a8def7;
-$blue-300: #7ccdf3;
-$blue-400: #51bdef;
-$blue-500: #1e8abc;
-$blue-600: #16678d;
-$blue-700: #135676;
-$blue-800: #0f455e;
-$blue-900: #0b3446;
+$blue-100: #E5F6FF;
+$blue-200: #A8DEF7;
+$blue-300: #5CC6FF;
+$blue-400: #009FF5;
+$blue-500: #007FC4;
+$blue-600: #006DA8;
+$blue-700: #005D8F;
+$blue-800: #003B5C;
+$blue-900: #001A29;
 $blue-1000: #07222f;
 
 
@@ -727,6 +727,7 @@ $nav-tabs-link-active-border-color: $primary;
 
 $nav-pills-border-radius:           0;
 $nav-pills-link-active-color:       $white;
+$nav-pills-link-hover-color:        $blue-700;
 $nav-pills-link-active-bg:          $blue-800;
 
 $nav-divider-color:                 $border-color;

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/entity_branding/nfg_theme/_nav.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/entity_branding/nfg_theme/_nav.scss
@@ -3,6 +3,7 @@
   &.flex-column {
     .nav-link {
       &:hover, &.active {
+        color: $nav-pills-link-active-color;
         &:after { background: var(--brand-primary); }
       }
     }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/core/entity_branding/nfg_theme/_navbar.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/core/entity_branding/nfg_theme/_navbar.scss
@@ -13,6 +13,6 @@
     .open > .nav-link,
     .active > .nav-link,
     .nav-link.open,
-    .nav-link.active { color: var(--brand-primary-yiq-text-darker); }
+    .nav-link.active { color: var(--brand-primary-yiq-text-light); }
   }
 }

--- a/app/assets/stylesheets/nfg_ui/network_for_good/public/nfg_theme/_nav.scss
+++ b/app/assets/stylesheets/nfg_ui/network_for_good/public/nfg_theme/_nav.scss
@@ -15,11 +15,12 @@
         transition: $btn-transition;
         content: '';
       }
-      &.active {
-        color: $nav-tabs-link-active-color !important;
+     &.active {
+        color: $nav-pills-link-active-color !important;
         &:after { background: $nav-tabs-link-hover-border-color; }
       }
-      @include hover-focus {
+      // Hover only when NOT active
+      &:not(.active):hover {
         color: $nav-tabs-link-active-color !important;
         &:after { background: $nav-tabs-link-hover-border-color; }
       }

--- a/app/views/nfg_ui/app_icons/_icons.html.haml
+++ b/app/views/nfg_ui/app_icons/_icons.html.haml
@@ -3,7 +3,7 @@
 = favicon_link_tag 'nfg_ui/app_icon/favicon-32x32.png', rel: 'icon', sizes: '32x32', type: 'image/png'
 = favicon_link_tag 'nfg_ui/app_icon/favicon-16x16.png', rel: 'icon', sizes: '16x16', type: 'image/png'
 = favicon_link_tag 'nfg_ui/app_icon/site.webmanifest', rel: 'manifest', type: nil
-= favicon_link_tag 'nfg_ui/app_icon/safari-pinned-tab.svg', color: '#25ACEB', rel: 'mask-icon', type: nil
+= favicon_link_tag 'nfg_ui/app_icon/safari-pinned-tab.svg', color: '#006DA8', rel: 'mask-icon', type: nil
 
 %meta{ content: '#ffffff', name: 'msapplication-TileColor' }
 %meta{ name: 'msapplication-config', content: asset_path('nfg_ui/app_icon/browserconfig.xml') }

--- a/lib/nfg_ui/version.rb
+++ b/lib/nfg_ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgUi
-  VERSION = '7.2.3'
+  VERSION = '7.3.0'
 end

--- a/spec/views/nfg_ui/app_icons/_icons.html.haml_spec.rb
+++ b/spec/views/nfg_ui/app_icons/_icons.html.haml_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'app/views/nfg_ui/app_icons/_icons.html.haml', type: :view do
   let(:favicon_attributes) { { href: 'nfg_ui/app_icon/favicon', rel: 'shortcut icon' } }
   let(:favicon_32x32_attributes) { { href: 'nfg_ui/app_icon/favicon-32x32', rel: 'icon', sizes: '32x32', type: 'image/png'} }
   let(:favicon_16x16_attributes) { { href: 'nfg_ui/app_icon/favicon-16x16', rel: 'icon', sizes: '32x32', type: 'image/png'} }
-  let(:safari_pinned_tab_attributes) { { href: 'nfg_ui/app_icon/safari-pinned-tab', rel: 'mask-icon', color: '#25ACEB' } }
+  let(:safari_pinned_tab_attributes) { { href: 'nfg_ui/app_icon/safari-pinned-tab', rel: 'mask-icon', color: '#006DA8' } }
 
   it 'includes the apple touch icon' do
     expect(subject).to have_css "link#{element_attributes(attributes: apple_touch_icon_attributes)}", visible: :all


### PR DESCRIPTION
## Summary
Accessibility-focused theme update (WCAG contrast) for the NFG theme, plus tightened button and nav color rules. Bumps nfg_ui to **7.3.0**.
Figma: https://www.figma.com/design/I3GHIox0jUCEySnh6dkMC2/Accessible-Colors?node-id=13-366&t=rZtHghjNkT6yIpax-11

## Changes
**Palette / tokens** (`core/_variables.scss`)
- Refreshes the blue (primary) scale (`$blue-100`–`$blue-900`) to higher-contrast values
- `$blue` (primary) → `#006DA8`
- `$red` → `#D92C2C`
- Adds `$nav-pills-link-hover-color: $blue-700`

**Buttons** (`admin/color_variations/nfg_theme/_buttons.scss`)
- Primary buttons now use `$primary` consistently (color + focus/active box-shadow), instead of the per-color `$value`
- Secondary / outline-secondary / link buttons use `$yiq-text-dark` for text color

**Nav** (`admin/.../nav`, `core/entity_branding/.../nav` & `navbar`, `public/.../nav`)
- Active/hover nav indicators use `$primary`
- Admin sidebar background `$blue-700` → `$blue-600`
- Active nav links no longer pick up hover styling (`&:not(.active):hover`); active state uses `$nav-pills-link-active-color`
- Entity-branding navbar active link → `var(--brand-primary-yiq-text-light)`

**App icon / favicon**
- Tile + mask-icon colors → `#006DA8` (`browserconfig.xml.erb`, `_icons.html.haml`)

## Versioning & changelog
- `lib/nfg_ui/version.rb` and `Gemfile.lock` → `7.3.0`
- `CHANGELOG.md` updated; merged latest `master` (incl. the `7.2.4` `$danger`/input-contrast work) — no conflicts remaining

## Notes
- `$red` and `$danger` are both `#D92C2C` after merge. `$red` is an unused base token (only a commented-out color-map reference), so this is intentional and has no visual impact; `$danger` remains the active error color.

## Testing
- Updated `spec/views/nfg_ui/app_icons/_icons.html.haml_spec.rb` for the new mask-icon color
- Remaining changes are SCSS token/selector updates (not unit-tested in this repo)

## Checklist
- [x] Full spec coverage for all changes
- [x] Version bumped (nfg_ui → 7.3.0)
- [x] Changelog includes version + summary
- [ ] nfg_ui_display_app PR created and component updates reflected — *display app Gemfile repointed from the (deleted) `rails_7_2` branch to `master`; lockfile bump to 7.3.0 pending this PR's merge*
